### PR TITLE
Add must-understand response directive support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Replace `AsyncResponseStream` with `AsyncCacheStream`. (#86)
+- Add `must-understand` response directive support. (#90)
 
 ## 0.0.13 (10/5/2023)
 

--- a/hishel/_controller.py
+++ b/hishel/_controller.py
@@ -174,6 +174,8 @@ class Controller:
         if request_cache_control.no_store:
             return False
 
+        # note that the must-understand cache directive overrides
+        # no-store in certain circumstances; see Section 5.2.2.3.
         if (
             response_cache_control.no_store
             and not response_cache_control.must_understand

--- a/hishel/_controller.py
+++ b/hishel/_controller.py
@@ -147,7 +147,6 @@ class Controller:
         `https://www.rfc-editor.org/rfc/rfc9111.html#name-storing-responses-in-caches`
         lists the steps that this method simply follows.
         """
-
         method = request.method.decode("ascii")
 
         if response.status not in self._cacheable_status_codes:
@@ -171,8 +170,14 @@ class Controller:
         if response.status // 100 == 1:
             return False
 
-        # the no-store cache directive is not present in the response (see Section 5.2.2.5)
-        if response_cache_control.no_store or request_cache_control.no_store:
+        # the no-store cache directive is not present (see Section 5.2.2.5)
+        if request_cache_control.no_store:
+            return False
+
+        if (
+            response_cache_control.no_store
+            and not response_cache_control.must_understand
+        ):
             return False
 
         expires_presents = header_presents(response.headers, b"expires")

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -723,3 +723,53 @@ def test_no_store_request_directive():
     controller = Controller()
 
     assert not controller.is_cachable(request=request, response=response)
+
+
+def test_no_store_response_directive():
+    request = Request(
+        method="GET",
+        url="https://example.com",
+        headers=[
+            (b"Content-Type", b"application/json"),
+            (b"Content-Language", b"en-US"),
+        ],
+    )
+
+    response = Response(
+        status=200,
+        headers=[
+            (b"Content-Type", b"application/json"),
+            (b"Content-Language", b"en-US"),
+            (b"Cache-Control", b"no-store, max-age=4000"),
+            (b"Date", b"Mon, 25 Aug 2015 12:00:00 GMT"),
+        ],
+    )
+
+    controller = Controller()
+
+    assert not controller.is_cachable(request=request, response=response)
+
+
+def test_must_understand_response_directive():
+    request = Request(
+        method="GET",
+        url="https://example.com",
+        headers=[
+            (b"Content-Type", b"application/json"),
+            (b"Content-Language", b"en-US"),
+        ],
+    )
+
+    response = Response(
+        status=200,
+        headers=[
+            (b"Content-Type", b"application/json"),
+            (b"Content-Language", b"en-US"),
+            (b"Cache-Control", b"no-store, must-understand, max-age=4000"),
+            (b"Date", b"Mon, 25 Aug 2015 12:00:00 GMT"),
+        ],
+    )
+
+    controller = Controller()
+
+    assert controller.is_cachable(request=request, response=response)


### PR DESCRIPTION
RFC 9111 added a must-understand response directive that can override the no-store response directive and make the response cachable.

See [must-understand](https://datatracker.ietf.org/doc/html/rfc9111#name-must-understand) for more information.