### PR TITLE
Add sqlite support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## unreleased
+
+- Add sqlite support. (#92)
+
 ## 0.0.14 (23/10/2023)
 
 - Replace `AsyncResponseStream` with `AsyncCacheStream`. (#86)

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -76,6 +76,13 @@ storage = hishel.RedisStorage()
 client = hishel.CacheTransport(transport=httpx.HTTPTransport())
 ```
 
+!!! note
+    Make sure `Hishel` has the redis extension installed if you want to use the `RedisStorage`.
+    ``` shell
+    $ pip install hishel[redis]
+    ```
+
+
 #### Specifying the host and port for redis.
 
 If you need to connect somewhere other than localhost, this is how you can do it.
@@ -105,6 +112,102 @@ storage = hishel.RedisStorage(ttl=3600)
 
 If you do this, `Hishel` will delete any stored responses whose ttl has expired.
 In this example, the stored responses were limited to 1 hour.
+
+### Using the SQLite storage
+
+`Hishel` includes built-in [sqlite](https://www.sqlite.org/index.html) support, allowing you to store your responses in sqlite database.
+
+Example:
+
+```python
+import hishel
+
+storage = hishel.SQLiteStorage()
+client = hishel.CacheClient(storage=storage)
+```
+
+Or if you are using Transports:
+
+```python
+import hishel
+import httpx
+
+storage = hishel.SQLiteStorage()
+client = hishel.CacheTransport(transport=httpx.HTTPTransport())
+```
+
+!!! note
+    Make sure `Hishel` has the sqlite extension installed if you want to use the `AsyncSQLiteStorage`.
+    ``` shell
+    $ pip install hishel[sqlite]
+    ```
+
+#### Specifying the sqlite connection to use.
+
+If you want more control over the underlying sqlite connection, you can explicitly pass it.
+
+```python
+import hishel
+import sqlite3
+
+client = hishel.CacheClient(
+    storage=hishel.SQLiteStorage(connection=sqlite3.connect("my_db_path", timeout=5))
+)
+```
+
+#### Specifying the responses ttl in SQLiteStorage.
+
+You can explicitly specify the ttl for stored responses in this manner.
+
+```python
+import hishel
+
+storage = hishel.SQLiteStorage(ttl=3600)
+```
+
+If you do this, `Hishel` will delete any stored responses whose ttl has expired.
+In this example, the stored responses were limited to 1 hour.
+
+
+## Which storage is the best?
+
+Let's start with some basic benchmarks to see which one is the fastest.
+
+So there are the results of the benchmarks, where we simply sent 1000 synchronous requests to [hishel.com](https://hishel.com).
+
+| Storage           | Time                          |
+| -----------       | ---- |
+| `FileStorage`     | 0.4s |
+| `SQLiteStorage`   | 2s   |
+| `RedisStorage`    | 0.5s |
+
+
+!!! note
+    It is important to note that the results may differ for your environment due to a variety of factors that we ignore.
+
+In most cases, `FileStorage` and `RedisStorage` are significantly faster than `SQLiteStorage`, but `SQLiteStorage` can be used if you already have a well-configured sqlite database and want to keep cached responses close to your application data. 
+
+For each storage option, there are some benefits.
+
+FileStorage
+
+1. **0 configuration**
+2. **very fast**
+3. **easy access**
+
+RedisStorage
+
+1. **can be shared**
+2. **very fast**
+3. **redis features**
+
+SQLiteStorage
+
+1. **can be shared**
+2. **sqlite features**
+
+!!! tip
+    Any [serializer](#serializers) can be used with any storage because they are all fully compatible.
 
 ## Serializers
 
@@ -250,7 +353,7 @@ storage = hishel.FileStorage(serializer=serializer)
 ```
 
 !!! note
-    Make sure `Hishel` has the yaml extension installed if you want to use the YAMLSerializer.
+    Make sure `Hishel` has the yaml extension installed if you want to use the `YAMLSerializer`.
     ``` shell
     $ pip install hishel[yaml]
     ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -10,6 +10,7 @@
 ## Storages
 
 ::: hishel.FileStorage
+::: hishel.SQLiteStorage
 ::: hishel.RedisStorage
 
 ## Serializers

--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -3,6 +3,7 @@ import time
 import typing as tp
 from pathlib import Path
 
+import anysqlite
 from httpcore import Request, Response
 
 from hishel._serializers import BaseSerializer
@@ -13,7 +14,7 @@ from .._synchronization import AsyncLock
 
 logger = logging.getLogger("hishel.storages")
 
-__all__ = ("AsyncFileStorage", "AsyncRedisStorage")
+__all__ = ("AsyncFileStorage", "AsyncRedisStorage", "AsyncSQLiteStorage")
 
 try:
     import redis.asyncio as redis
@@ -134,6 +135,126 @@ class AsyncFileStorage(AsyncBaseStorage):
                     age = time.time() - file.stat().st_mtime
                     if age > self._ttl:
                         file.unlink()
+
+
+class AsyncSQLiteStorage(AsyncBaseStorage):
+    """
+    A simple sqlite3 storage.
+
+    :param serializer: Serializer capable of serializing and de-serializing http responses, defaults to None
+    :type serializer: tp.Optional[BaseSerializer], optional
+    :param connection: A connection for sqlite, defaults to None
+    :type connection: tp.Optional[anysqlite.Connection], optional
+    :param ttl: Specifies the maximum number of seconds that the response can be cached, defaults to None
+    :type ttl: tp.Optional[int], optional
+    """
+
+    def __init__(
+        self,
+        serializer: tp.Optional[BaseSerializer] = None,
+        connection: tp.Optional[anysqlite.Connection] = None,  # type: ignore
+        ttl: tp.Optional[int] = None,
+    ) -> None:
+        if anysqlite is None:  # pragma: no cover
+            raise RuntimeError(
+                (
+                    f"The `{type(self).__name__}` was used, but the required packages were not found. "
+                    "Check that you have `Hishel` installed with the `sqlite` extension as shown.\n"
+                    "```pip install hishel[sqlite]```"
+                )
+            )
+        super().__init__(serializer)
+
+        self._connection: tp.Optional[anysqlite.Connection] = connection or None
+        self._setup_lock = AsyncLock()
+        self._setup_completed: bool = False
+        self._lock = AsyncLock()
+        self._ttl = ttl
+
+    async def _setup(self) -> None:
+        async with self._setup_lock:
+            if not self._setup_completed:
+                self._connection = await anysqlite.connect(".hishel.sqlite")
+                await self._connection.execute(
+                    (
+                        "CREATE TABLE IF NOT EXISTS cache(key TEXT, data BLOB, "
+                        "date_created datetime DEFAULT CURRENT_TIMESTAMP)"
+                    )
+                )
+                await self._connection.commit()
+                self._setup_completed = True
+
+    async def store(
+        self, key: str, response: Response, request: Request, metadata: Metadata
+    ) -> None:
+        """
+        Stores the response in the cache.
+
+        :param key: Hashed value of concatenated HTTP method and URI
+        :type key: str
+        :param response: An HTTP response
+        :type response: httpcore.Response
+        :param request: An HTTP request
+        :type request: httpcore.Request
+        :param metadata: Additioal information about the stored response
+        :type metadata: Metadata
+        """
+
+        await self._setup()
+        assert self._connection
+
+        async with self._lock:
+            await self._connection.execute("DELETE FROM cache WHERE key = ?", [key])
+            serialized_response = self._serializer.dumps(
+                response=response, request=request, metadata=metadata
+            )
+            await self._connection.execute(
+                "INSERT INTO cache(key, data) VALUES(?, ?)", [key, serialized_response]
+            )
+            await self._connection.commit()
+        await self._remove_expired_caches()
+
+    async def retreive(
+        self, key: str
+    ) -> tp.Optional[tp.Tuple[Response, Request, Metadata]]:
+        """
+        Retreives the response from the cache using his key.
+
+        :param key: Hashed value of concatenated HTTP method and URI
+        :type key: str
+        :return: An HTTP response and its HTTP request.
+        :rtype: tp.Optional[tp.Tuple[Response, Request, Metadata]]
+        """
+
+        await self._setup()
+        assert self._connection
+
+        async with self._lock:
+            cursor = await self._connection.execute(
+                "SELECT data FROM cache WHERE key = ?", [key]
+            )
+            row = await cursor.fetchone()
+            if row is None:
+                return None
+
+            cached_response = row[0]
+            return self._serializer.loads(cached_response)
+        await self._remove_expired_caches()
+
+    async def aclose(self) -> None:  # pragma: no cover
+        assert self._connection
+        await self._connection.close()
+
+    async def _remove_expired_caches(self) -> None:
+        assert self._connection
+        if self._ttl is None:
+            return
+
+        async with self._lock:
+            await self._connection.execute(
+                f"DELETE FROM cache WHERE datetime(date_created, '+{self._ttl} seconds') > datetime()"
+            )
+            await self._connection.commit()
 
 
 class AsyncRedisStorage(AsyncBaseStorage):

--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -174,9 +174,10 @@ class AsyncSQLiteStorage(AsyncBaseStorage):
     async def _setup(self) -> None:
         async with self._setup_lock:
             if not self._setup_completed:
-                self._connection = await anysqlite.connect(
-                    ".hishel.sqlite", check_same_thread=False
-                )
+                if not self._connection:
+                    self._connection = await anysqlite.connect(
+                        ".hishel.sqlite", check_same_thread=False
+                    )
                 await self._connection.execute(
                     (
                         "CREATE TABLE IF NOT EXISTS cache(key TEXT, data BLOB, "

--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -3,7 +3,11 @@ import time
 import typing as tp
 from pathlib import Path
 
-import anysqlite
+try:
+    import anysqlite
+except ImportError:
+    anysqlite = None
+
 from httpcore import Request, Response
 
 from hishel._serializers import BaseSerializer
@@ -152,7 +156,7 @@ class AsyncSQLiteStorage(AsyncBaseStorage):
     def __init__(
         self,
         serializer: tp.Optional[BaseSerializer] = None,
-        connection: tp.Optional[anysqlite.Connection] = None,  # type: ignore
+        connection: tp.Optional["anysqlite.Connection"] = None,  # type: ignore
         ttl: tp.Optional[int] = None,
     ) -> None:
         if anysqlite is None:  # pragma: no cover

--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -156,7 +156,7 @@ class AsyncSQLiteStorage(AsyncBaseStorage):
     def __init__(
         self,
         serializer: tp.Optional[BaseSerializer] = None,
-        connection: tp.Optional["anysqlite.Connection"] = None,  # type: ignore
+        connection: tp.Optional["anysqlite.Connection"] = None,
         ttl: tp.Optional[int] = None,
     ) -> None:
         if anysqlite is None:  # pragma: no cover

--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -5,8 +5,8 @@ from pathlib import Path
 
 try:
     import anysqlite
-except ImportError:
-    anysqlite = None
+except ImportError:  # pragma: no cover
+    anysqlite = None  # type: ignore
 
 from httpcore import Request, Response
 

--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -174,7 +174,7 @@ class AsyncSQLiteStorage(AsyncBaseStorage):
     async def _setup(self) -> None:
         async with self._setup_lock:
             if not self._setup_completed:
-                if not self._connection:
+                if not self._connection:  # pragma: no cover
                     self._connection = await anysqlite.connect(
                         ".hishel.sqlite", check_same_thread=False
                     )

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -174,9 +174,10 @@ class SQLiteStorage(BaseStorage):
     def _setup(self) -> None:
         with self._setup_lock:
             if not self._setup_completed:
-                self._connection = sqlite3.connect(
-                    ".hishel.sqlite", check_same_thread=False
-                )
+                if not self._connection:
+                    self._connection = sqlite3.connect(
+                        ".hishel.sqlite", check_same_thread=False
+                    )
                 self._connection.execute(
                     (
                         "CREATE TABLE IF NOT EXISTS cache(key TEXT, data BLOB, "

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -174,7 +174,7 @@ class SQLiteStorage(BaseStorage):
     def _setup(self) -> None:
         with self._setup_lock:
             if not self._setup_completed:
-                if not self._connection:
+                if not self._connection:  # pragma: no cover
                     self._connection = sqlite3.connect(
                         ".hishel.sqlite", check_same_thread=False
                     )

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -3,6 +3,7 @@ import time
 import typing as tp
 from pathlib import Path
 
+import sqlite3
 from httpcore import Request, Response
 
 from hishel._serializers import BaseSerializer
@@ -13,7 +14,7 @@ from .._synchronization import Lock
 
 logger = logging.getLogger("hishel.storages")
 
-__all__ = ("FileStorage", "RedisStorage")
+__all__ = ("FileStorage", "RedisStorage", "SQLiteStorage")
 
 try:
     import redis
@@ -134,6 +135,126 @@ class FileStorage(BaseStorage):
                     age = time.time() - file.stat().st_mtime
                     if age > self._ttl:
                         file.unlink()
+
+
+class SQLiteStorage(BaseStorage):
+    """
+    A simple sqlite3 storage.
+
+    :param serializer: Serializer capable of serializing and de-serializing http responses, defaults to None
+    :type serializer: tp.Optional[BaseSerializer], optional
+    :param connection: A connection for sqlite, defaults to None
+    :type connection: tp.Optional[sqlite3.Connection], optional
+    :param ttl: Specifies the maximum number of seconds that the response can be cached, defaults to None
+    :type ttl: tp.Optional[int], optional
+    """
+
+    def __init__(
+        self,
+        serializer: tp.Optional[BaseSerializer] = None,
+        connection: tp.Optional[sqlite3.Connection] = None,  # type: ignore
+        ttl: tp.Optional[int] = None,
+    ) -> None:
+        if sqlite3 is None:  # pragma: no cover
+            raise RuntimeError(
+                (
+                    f"The `{type(self).__name__}` was used, but the required packages were not found. "
+                    "Check that you have `Hishel` installed with the `sqlite` extension as shown.\n"
+                    "```pip install hishel[sqlite]```"
+                )
+            )
+        super().__init__(serializer)
+
+        self._connection: tp.Optional[sqlite3.Connection] = connection or None
+        self._setup_lock = Lock()
+        self._setup_completed: bool = False
+        self._lock = Lock()
+        self._ttl = ttl
+
+    def _setup(self) -> None:
+        with self._setup_lock:
+            if not self._setup_completed:
+                self._connection = sqlite3.connect(".hishel.sqlite")
+                self._connection.execute(
+                    (
+                        "CREATE TABLE IF NOT EXISTS cache(key TEXT, data BLOB, "
+                        "date_created datetime DEFAULT CURRENT_TIMESTAMP)"
+                    )
+                )
+                self._connection.commit()
+                self._setup_completed = True
+
+    def store(
+        self, key: str, response: Response, request: Request, metadata: Metadata
+    ) -> None:
+        """
+        Stores the response in the cache.
+
+        :param key: Hashed value of concatenated HTTP method and URI
+        :type key: str
+        :param response: An HTTP response
+        :type response: httpcore.Response
+        :param request: An HTTP request
+        :type request: httpcore.Request
+        :param metadata: Additioal information about the stored response
+        :type metadata: Metadata
+        """
+
+        self._setup()
+        assert self._connection
+
+        with self._lock:
+            self._connection.execute("DELETE FROM cache WHERE key = ?", [key])
+            serialized_response = self._serializer.dumps(
+                response=response, request=request, metadata=metadata
+            )
+            self._connection.execute(
+                "INSERT INTO cache(key, data) VALUES(?, ?)", [key, serialized_response]
+            )
+            self._connection.commit()
+        self._remove_expired_caches()
+
+    def retreive(
+        self, key: str
+    ) -> tp.Optional[tp.Tuple[Response, Request, Metadata]]:
+        """
+        Retreives the response from the cache using his key.
+
+        :param key: Hashed value of concatenated HTTP method and URI
+        :type key: str
+        :return: An HTTP response and its HTTP request.
+        :rtype: tp.Optional[tp.Tuple[Response, Request, Metadata]]
+        """
+
+        self._setup()
+        assert self._connection
+
+        with self._lock:
+            cursor = self._connection.execute(
+                "SELECT data FROM cache WHERE key = ?", [key]
+            )
+            row = cursor.fetchone()
+            if row is None:
+                return None
+
+            cached_response = row[0]
+            return self._serializer.loads(cached_response)
+        self._remove_expired_caches()
+
+    def close(self) -> None:  # pragma: no cover
+        assert self._connection
+        self._connection.close()
+
+    def _remove_expired_caches(self) -> None:
+        assert self._connection
+        if self._ttl is None:
+            return
+
+        with self._lock:
+            self._connection.execute(
+                f"DELETE FROM cache WHERE datetime(date_created, '+{self._ttl} seconds') > datetime()"
+            )
+            self._connection.commit()
 
 
 class RedisStorage(BaseStorage):

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -5,8 +5,8 @@ from pathlib import Path
 
 try:
     import sqlite3
-except ImportError:
-    sqlite3 = None
+except ImportError:  # pragma: no cover
+    sqlite3 = None  # type: ignore
 
 from httpcore import Request, Response
 

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -3,7 +3,11 @@ import time
 import typing as tp
 from pathlib import Path
 
-import sqlite3
+try:
+    import sqlite3
+except ImportError:
+    sqlite3 = None
+
 from httpcore import Request, Response
 
 from hishel._serializers import BaseSerializer
@@ -152,7 +156,7 @@ class SQLiteStorage(BaseStorage):
     def __init__(
         self,
         serializer: tp.Optional[BaseSerializer] = None,
-        connection: tp.Optional[sqlite3.Connection] = None,  # type: ignore
+        connection: tp.Optional["sqlite3.Connection"] = None,  # type: ignore
         ttl: tp.Optional[int] = None,
     ) -> None:
         if sqlite3 is None:  # pragma: no cover

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -156,7 +156,7 @@ class SQLiteStorage(BaseStorage):
     def __init__(
         self,
         serializer: tp.Optional[BaseSerializer] = None,
-        connection: tp.Optional["sqlite3.Connection"] = None,  # type: ignore
+        connection: tp.Optional["sqlite3.Connection"] = None,
         ttl: tp.Optional[int] = None,
     ) -> None:
         if sqlite3 is None:  # pragma: no cover

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ markdown_extensions:
   - pymdownx.highlight:
       anchor_linenums: true
   - pymdownx.superfences 
+  - tables
 
 plugins:
 - mkdocstrings:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,10 @@ redis = [
     "redis==5.0.0"
 ]
 
+sqlite = [
+    "anysqlite>=0.0.5"
+]
+
 [project.urls]
 Homepage = "https://hishel.com"
 Source = "https://github.com/karpetrosyan/hishel"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e .[yaml,redis]
+-e .[yaml,redis,sqlite]
 
 # linting
 ruff==0.0.291

--- a/tests/_async/test_storages.py
+++ b/tests/_async/test_storages.py
@@ -1,9 +1,10 @@
 import datetime
 
+import anysqlite
 import pytest
 from httpcore import Request, Response
 
-from hishel import AsyncFileStorage, AsyncRedisStorage
+from hishel import AsyncFileStorage, AsyncRedisStorage, AsyncSQLiteStorage
 from hishel._serializers import Metadata
 from hishel._utils import asleep, generate_key
 
@@ -74,6 +75,31 @@ async def test_redisstorage():
     assert stored_response.content == b"test"
 
 
+@pytest.mark.anyio
+async def test_sqlitestorage():
+    storage = AsyncSQLiteStorage(connection=await anysqlite.connect(":memory:"))
+
+    request = Request(b"GET", "https://example.com")
+
+    key = generate_key(request)
+
+    response = Response(200, headers=[], content=b"test")
+    await response.aread()
+
+    await storage.store(
+        key, response=response, request=request, metadata=dummy_metadata
+    )
+
+    stored_data = await storage.retreive(key)
+    assert stored_data is not None
+    stored_response, stored_request, metadata = stored_data
+    stored_response.read()
+    assert isinstance(stored_response, Response)
+    assert stored_response.status == 200
+    assert stored_response.headers == []
+    assert stored_response.content == b"test"
+
+
 @pytest.mark.asyncio
 async def test_filestorage_expired():
     storage = AsyncFileStorage(ttl=1)
@@ -103,6 +129,30 @@ async def test_redisstorage_expired():
     if is_redis_down():  # pragma: no cover
         pytest.fail("Redis server was not found")
     storage = AsyncRedisStorage(ttl=1)
+    first_request = Request(b"GET", "https://example.com")
+    second_request = Request(b"GET", "https://anotherexample.com")
+
+    first_key = generate_key(first_request)
+    second_key = generate_key(second_request)
+
+    response = Response(200, headers=[], content=b"test")
+    await response.aread()
+
+    await storage.store(
+        first_key, response=response, request=first_request, metadata=dummy_metadata
+    )
+
+    await asleep(1)
+    await storage.store(
+        second_key, response=response, request=second_request, metadata=dummy_metadata
+    )
+
+    assert await storage.retreive(first_key) is None
+
+
+@pytest.mark.asyncio
+async def test_sqlite_expired():
+    storage = AsyncSQLiteStorage(ttl=1, connection=await anysqlite.connect(":memory:"))
     first_request = Request(b"GET", "https://example.com")
     second_request = Request(b"GET", "https://anotherexample.com")
 

--- a/tests/_sync/test_storages.py
+++ b/tests/_sync/test_storages.py
@@ -1,9 +1,10 @@
 import datetime
 
+import sqlite3
 import pytest
 from httpcore import Request, Response
 
-from hishel import FileStorage, RedisStorage
+from hishel import FileStorage, RedisStorage, SQLiteStorage
 from hishel._serializers import Metadata
 from hishel._utils import sleep, generate_key
 
@@ -75,6 +76,31 @@ def test_redisstorage():
 
 
 
+def test_sqlitestorage():
+    storage = SQLiteStorage(connection=sqlite3.connect(":memory:"))
+
+    request = Request(b"GET", "https://example.com")
+
+    key = generate_key(request)
+
+    response = Response(200, headers=[], content=b"test")
+    response.read()
+
+    storage.store(
+        key, response=response, request=request, metadata=dummy_metadata
+    )
+
+    stored_data = storage.retreive(key)
+    assert stored_data is not None
+    stored_response, stored_request, metadata = stored_data
+    stored_response.read()
+    assert isinstance(stored_response, Response)
+    assert stored_response.status == 200
+    assert stored_response.headers == []
+    assert stored_response.content == b"test"
+
+
+
 def test_filestorage_expired():
     storage = FileStorage(ttl=1)
     first_request = Request(b"GET", "https://example.com")
@@ -103,6 +129,30 @@ def test_redisstorage_expired():
     if is_redis_down():  # pragma: no cover
         pytest.fail("Redis server was not found")
     storage = RedisStorage(ttl=1)
+    first_request = Request(b"GET", "https://example.com")
+    second_request = Request(b"GET", "https://anotherexample.com")
+
+    first_key = generate_key(first_request)
+    second_key = generate_key(second_request)
+
+    response = Response(200, headers=[], content=b"test")
+    response.read()
+
+    storage.store(
+        first_key, response=response, request=first_request, metadata=dummy_metadata
+    )
+
+    sleep(1)
+    storage.store(
+        second_key, response=response, request=second_request, metadata=dummy_metadata
+    )
+
+    assert storage.retreive(first_key) is None
+
+
+
+def test_sqlite_expired():
+    storage = SQLiteStorage(ttl=1, connection=sqlite3.connect(":memory:"))
     first_request = Request(b"GET", "https://example.com")
     second_request = Request(b"GET", "https://anotherexample.com")
 

--- a/unasync.py
+++ b/unasync.py
@@ -16,6 +16,7 @@ SUBS = [
     ('MockAsyncConnectionPool', 'MockConnectionPool'),
     ('MockAsyncTransport', 'MockTransport'),
     ('AsyncRedisStorage', 'RedisStorage'),
+    ('AsyncSQLiteStorage', 'SQLiteStorage'),
     ('import redis.asyncio as redis', 'import redis'),
     ('AsyncCacheTransport', 'CacheTransport'),
     ('AsyncBaseTransport', 'BaseTransport'),
@@ -38,6 +39,7 @@ SUBS = [
     ('__aexit__', '__exit__'),
     ('*@pytest.mark.anyio', ''),
     ('*@pytest.mark.asyncio', ''),
+    ('anysqlite', 'sqlite3'),
 ]
 COMPILED_SUBS = [
     (re.compile(r'(^|\b)' + regex + r'($|\b)'), repl)


### PR DESCRIPTION
Closes #89 

This pull request adds basic `sqlite3` support for all kinds of [serializers](https://hishel.com/advanced/#serializers) and can work on top of either trio or asyncio.