### PR TITLE
Add install_cache function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- Add `install_cache` function. (#95)
 - Add sqlite support. (#92)
 
 ## 0.0.14 (23/10/2023)

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -6,13 +6,16 @@ It is very simple to integrate with your existing application; simply change the
 
 ## Clients and Transports
 
-There are two ways to make the httpx library cacheable when working with it.
+There are three ways to make the httpx library cacheable when working with it.
 
 - Use the class provided by `Hishel` to completely replace `HTTPX's Client`.
 - Simply use your existing httpx client along with `Hishel's transports`.
+- Mock the httpx classes using the `hishel.install_cache` function.
 
 It is always advised to use the second option because it is more reliable and adaptable.
 
+!!! warning
+    Use the `hishel.install_cache` function only for experiments, and do not rely on the functionality provided by `hishel.install_cache`.
 
 ### Using the Clients
 

--- a/hishel/__init__.py
+++ b/hishel/__init__.py
@@ -1,8 +1,16 @@
-from ._async import *  # noqa: F403
-from ._controller import *  # noqa: F403
-from ._exceptions import *  # noqa: F403
-from ._headers import *  # noqa: F403
-from ._serializers import *  # noqa: F403
-from ._sync import *  # noqa: F403
+import httpx
+
+from ._async import *
+from ._controller import *
+from ._exceptions import *
+from ._headers import *
+from ._serializers import *
+from ._sync import *
+
+
+def install_cache() -> None:  # pragma: no cover
+    httpx.AsyncClient = AsyncCacheClient  # type: ignore
+    httpx.Client = CacheClient  # type: ignore
+
 
 __version__ = "0.0.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ exclude_also = [
 [tool.ruff]
 exclude = [
     "hishel/_sync",
+    "hishel/__init__.py",
     "tests/_sync",
 ]
 line-length = 120

--- a/scripts/check
+++ b/scripts/check
@@ -1,6 +1,5 @@
 #! /bin/bash -ex
 
-
 black --check --diff --exclude '/(_sync)/' tests hishel
 ruff tests hishel
 mypy tests hishel

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,5 +1,5 @@
 #! /bin/bash -ex
 
-black hishel tests
+black --exclude '/(_sync)/' hishel tests
 ruff --fix hishel tests
 python unasync.py


### PR DESCRIPTION
This pull request simply adds the `install_cache` function, which mocks the `httpx.Client` and `httpx.AsyncClient` and adds HTTP caching on top.

Example:

```python
import hishel
import httpx

hishel.install_cache()

client = httpx.Client()
client.get("https://hishel.com")
client.get("https://hishel.com")  # takes from the cache
```