### PR TITLE
Version 0.0.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.0.17 (6/11/2023) 
 
 - Fix `Last-Modified` validation.
 

--- a/hishel/__init__.py
+++ b/hishel/__init__.py
@@ -13,4 +13,4 @@ def install_cache() -> None:  # pragma: no cover
     httpx.Client = CacheClient  # type: ignore
 
 
-__version__ = "0.0.16"
+__version__ = "0.0.17"


### PR DESCRIPTION
# Changelog

## 0.0.17 (6/11/2023) 

- Fix `Last-Modified` validation.

