### PR TITLE
Use ruff for formatting

### DIFF
--- a/hishel/_async/_mock.py
+++ b/hishel/_async/_mock.py
@@ -12,9 +12,7 @@ __all__ = ("MockAsyncConnectionPool", "MockAsyncTransport")
 
 
 class MockAsyncConnectionPool(AsyncRequestInterface):
-    async def handle_async_request(
-        self, request: httpcore.Request
-    ) -> httpcore.Response:
+    async def handle_async_request(self, request: httpcore.Request) -> httpcore.Response:
         return self.mocked_responses.pop(0)
 
     def add_responses(self, responses: tp.List[httpcore.Response]) -> None:

--- a/hishel/_controller.py
+++ b/hishel/_controller.py
@@ -46,17 +46,13 @@ def get_updated_headers(
 
 
 def get_freshness_lifetime(response: Response) -> tp.Optional[int]:
-    response_cache_control = parse_cache_control(
-        extract_header_values_decoded(response.headers, b"Cache-Control")
-    )
+    response_cache_control = parse_cache_control(extract_header_values_decoded(response.headers, b"Cache-Control"))
 
     if response_cache_control.max_age is not None:
         return response_cache_control.max_age
 
     if header_presents(response.headers, b"expires"):
-        expires = extract_header_values_decoded(
-            response.headers, b"expires", single=True
-        )[0]
+        expires = extract_header_values_decoded(response.headers, b"expires", single=True)[0]
         expires_timestamp = parse_date(expires)
         date = extract_header_values_decoded(response.headers, b"date", single=True)[0]
         date_timestamp = parse_date(date)
@@ -66,9 +62,7 @@ def get_freshness_lifetime(response: Response) -> tp.Optional[int]:
 
 
 def get_heuristic_freshness(response: Response, clock: "BaseClock") -> int:
-    last_modified = extract_header_values_decoded(
-        response.headers, b"last-modified", single=True
-    )
+    last_modified = extract_header_values_decoded(response.headers, b"last-modified", single=True)
 
     if last_modified:
         last_modified_timestamp = parse_date(last_modified[0])
@@ -95,9 +89,7 @@ def get_age(response: Response, clock: "BaseClock") -> int:
 
 
 def allowed_stale(response: Response) -> bool:
-    response_cache_control = parse_cache_control(
-        extract_header_values_decoded(response.headers, b"Cache-Control")
-    )
+    response_cache_control = parse_cache_control(extract_header_values_decoded(response.headers, b"Cache-Control"))
 
     if response_cache_control.no_cache:
         return False
@@ -130,9 +122,7 @@ class Controller:
                     )
                 self._cacheable_methods.append(method.upper())
 
-        self._cacheable_status_codes = (
-            cacheable_status_codes if cacheable_status_codes else [200, 301, 308]
-        )
+        self._cacheable_status_codes = cacheable_status_codes if cacheable_status_codes else [200, 301, 308]
         self._clock = clock if clock else Clock()
         self._allow_heuristics = allow_heuristics
         self._allow_stale = allow_stale
@@ -159,12 +149,8 @@ class Controller:
         if method not in self._cacheable_methods:
             return False
 
-        response_cache_control = parse_cache_control(
-            extract_header_values_decoded(response.headers, b"cache-control")
-        )
-        request_cache_control = parse_cache_control(
-            extract_header_values_decoded(request.headers, b"cache-control")
-        )
+        response_cache_control = parse_cache_control(extract_header_values_decoded(response.headers, b"cache-control"))
+        request_cache_control = parse_cache_control(extract_header_values_decoded(request.headers, b"cache-control"))
 
         # the response status code is final
         if response.status // 100 == 1:
@@ -176,10 +162,7 @@ class Controller:
 
         # note that the must-understand cache directive overrides
         # no-store in certain circumstances; see Section 5.2.2.3.
-        if (
-            response_cache_control.no_store
-            and not response_cache_control.must_understand
-        ):
+        if response_cache_control.no_store and not response_cache_control.must_understand:
             return False
 
         expires_presents = header_presents(response.headers, b"expires")
@@ -218,9 +201,7 @@ class Controller:
         """
 
         if header_presents(response.headers, b"last-modified"):
-            last_modified = extract_header_values(
-                response.headers, b"last-modified", single=True
-            )[0]
+            last_modified = extract_header_values(response.headers, b"last-modified", single=True)[0]
         else:
             last_modified = None
 
@@ -237,9 +218,7 @@ class Controller:
 
         request.headers.extend(precondition_headers)
 
-    def _validate_vary(
-        self, request: Request, response: Response, original_request: Request
-    ) -> bool:
+    def _validate_vary(self, request: Request, response: Response, original_request: Request) -> bool:
         """
         Determines whether the "vary" headers in the request and response headers are identical.
 
@@ -252,9 +231,9 @@ class Controller:
             if vary_header == "*":
                 return False  # pragma: no cover
 
-            if extract_header_values(
-                request.headers, vary_header
-            ) != extract_header_values(original_request.headers, vary_header):
+            if extract_header_values(request.headers, vary_header) != extract_header_values(
+                original_request.headers, vary_header
+            ):
                 return False
 
         return True
@@ -282,18 +261,12 @@ class Controller:
         if response.status in (301, 308):
             return response
 
-        response_cache_control = parse_cache_control(
-            extract_header_values_decoded(response.headers, b"Cache-Control")
-        )
-        request_cache_control = parse_cache_control(
-            extract_header_values_decoded(request.headers, b"Cache-Control")
-        )
+        response_cache_control = parse_cache_control(extract_header_values_decoded(response.headers, b"Cache-Control"))
+        request_cache_control = parse_cache_control(extract_header_values_decoded(request.headers, b"Cache-Control"))
 
         # request header fields nominated by the stored
         # response (if any) match those presented (see Section 4.1)
-        if not self._validate_vary(
-            request=request, response=response, original_request=original_request
-        ):
+        if not self._validate_vary(request=request, response=response, original_request=original_request):
             # If the vary headers does not match, then do not use the response
             return None  # pragma: no cover
 
@@ -313,9 +286,7 @@ class Controller:
 
         if freshness_lifetime is None:
             if self._allow_heuristics and response.status in HEURISTICALLY_CACHABLE:
-                freshness_lifetime = get_heuristic_freshness(
-                    response=response, clock=self._clock
-                )
+                freshness_lifetime = get_heuristic_freshness(response=response, clock=self._clock)
             else:
                 # If Freshness cannot be calculated, then send the request
                 self._make_request_conditional(request=request, response=response)
@@ -368,9 +339,7 @@ class Controller:
             self._make_request_conditional(request=request, response=response)
             return request
 
-    def handle_validation_response(
-        self, old_response: Response, new_response: Response
-    ) -> Response:
+    def handle_validation_response(self, old_response: Response, new_response: Response) -> Response:
         """
         Handles incoming validation response.
 

--- a/hishel/_files.py
+++ b/hishel/_files.py
@@ -7,29 +7,21 @@ class AsyncBaseFileManager:
     def __init__(self, is_binary: bool) -> None:
         self.is_binary = is_binary
 
-    async def write_to(
-        self, path: str, data: tp.Union[bytes, str], is_binary: tp.Optional[bool] = None
-    ) -> None:
+    async def write_to(self, path: str, data: tp.Union[bytes, str], is_binary: tp.Optional[bool] = None) -> None:
         raise NotImplementedError()
 
-    async def read_from(
-        self, path: str, is_binary: tp.Optional[bool] = None
-    ) -> tp.Union[bytes, str]:
+    async def read_from(self, path: str, is_binary: tp.Optional[bool] = None) -> tp.Union[bytes, str]:
         raise NotImplementedError()
 
 
 class AsyncFileManager(AsyncBaseFileManager):
-    async def write_to(
-        self, path: str, data: tp.Union[bytes, str], is_binary: tp.Optional[bool] = None
-    ) -> None:
+    async def write_to(self, path: str, data: tp.Union[bytes, str], is_binary: tp.Optional[bool] = None) -> None:
         is_binary = self.is_binary if is_binary is None else is_binary
         mode = "wb" if is_binary else "wt"
         async with await anyio.open_file(path, mode) as f:  # type: ignore[call-overload]
             await f.write(data)
 
-    async def read_from(
-        self, path: str, is_binary: tp.Optional[bool] = None
-    ) -> tp.Union[bytes, str]:
+    async def read_from(self, path: str, is_binary: tp.Optional[bool] = None) -> tp.Union[bytes, str]:
         is_binary = self.is_binary if is_binary is None else is_binary
         mode = "rb" if is_binary else "rt"
 
@@ -41,29 +33,21 @@ class BaseFileManager:
     def __init__(self, is_binary: bool) -> None:
         self.is_binary = is_binary
 
-    def write_to(
-        self, path: str, data: tp.Union[bytes, str], is_binary: tp.Optional[bool] = None
-    ) -> None:
+    def write_to(self, path: str, data: tp.Union[bytes, str], is_binary: tp.Optional[bool] = None) -> None:
         raise NotImplementedError()
 
-    def read_from(
-        self, path: str, is_binary: tp.Optional[bool] = None
-    ) -> tp.Union[bytes, str]:
+    def read_from(self, path: str, is_binary: tp.Optional[bool] = None) -> tp.Union[bytes, str]:
         raise NotImplementedError()
 
 
 class FileManager(BaseFileManager):
-    def write_to(
-        self, path: str, data: tp.Union[bytes, str], is_binary: tp.Optional[bool] = None
-    ) -> None:
+    def write_to(self, path: str, data: tp.Union[bytes, str], is_binary: tp.Optional[bool] = None) -> None:
         is_binary = self.is_binary if is_binary is None else is_binary
         mode = "wb" if is_binary else "wt"
         with open(path, mode) as f:
             f.write(data)
 
-    def read_from(
-        self, path: str, is_binary: tp.Optional[bool] = None
-    ) -> tp.Union[bytes, str]:
+    def read_from(self, path: str, is_binary: tp.Optional[bool] = None) -> tp.Union[bytes, str]:
         is_binary = self.is_binary if is_binary is None else is_binary
         mode = "rb" if is_binary else "rt"
         with open(path, mode) as f:

--- a/hishel/_headers.py
+++ b/hishel/_headers.py
@@ -96,22 +96,18 @@ def parse_cache_control(cache_control_values: List[str]) -> "CacheControl":
                         for value_char in value:
                             if value_char not in tchar:
                                 raise ParseError(
-                                    f"The character '{value_char!r}' "
-                                    "is not permitted for the unquoted values."
+                                    f"The character '{value_char!r}' " "is not permitted for the unquoted values."
                                 )
                     else:
                         for value_char in value[1:-1]:
                             if value_char not in qdtext:
                                 raise ParseError(
-                                    f"The character '{value_char!r}' "
-                                    "is not permitted for the quoted values."
+                                    f"The character '{value_char!r}' " "is not permitted for the quoted values."
                                 )
                     break
 
                 if key_char not in tchar:
-                    raise ParseError(
-                        f"The character '{key_char!r}' is not permitted in the directive name."
-                    )
+                    raise ParseError(f"The character '{key_char!r}' is not permitted in the directive name.")
                 key += key_char
             directives[key] = value
     validated_data = CacheControl.validate(directives)
@@ -178,26 +174,18 @@ class CacheControl:
             key = normalize_directive(key)
             if key in TIME_FIELDS:
                 if value is None:
-                    raise ValidationError(
-                        f"The directive '{key}' necessitates a value."
-                    )
+                    raise ValidationError(f"The directive '{key}' necessitates a value.")
 
                 if value[0] == '"' or value[-1] == '"':
-                    raise ValidationError(
-                        f"The argument '{key}' should be an integer, but a quote was found."
-                    )
+                    raise ValidationError(f"The argument '{key}' should be an integer, but a quote was found.")
 
                 try:
                     validated_data[key] = int(value)
                 except Exception:
-                    raise ValidationError(
-                        f"The argument '{key}' should be an integer, but got '{value!r}'."
-                    )
+                    raise ValidationError(f"The argument '{key}' should be an integer, but got '{value!r}'.")
             elif key in BOOLEAN_FIELDS:
                 if value is not None:
-                    raise ValidationError(
-                        f"The directive '{key}' should have no value, but it does."
-                    )
+                    raise ValidationError(f"The directive '{key}' should have no value, but it does.")
                 validated_data[key] = True
             elif key in LIST_FIELDS:
                 if value is None:

--- a/hishel/_serializers.py
+++ b/hishel/_serializers.py
@@ -27,14 +27,10 @@ class Metadata(tp.TypedDict):
 
 
 class BaseSerializer:
-    def dumps(
-        self, response: Response, request: Request, metadata: Metadata
-    ) -> tp.Union[str, bytes]:
+    def dumps(self, response: Response, request: Request, metadata: Metadata) -> tp.Union[str, bytes]:
         raise NotImplementedError()
 
-    def loads(
-        self, data: tp.Union[str, bytes]
-    ) -> tp.Tuple[Response, Request, Metadata]:
+    def loads(self, data: tp.Union[str, bytes]) -> tp.Tuple[Response, Request, Metadata]:
         raise NotImplementedError()
 
     @property
@@ -47,9 +43,7 @@ class PickleSerializer(BaseSerializer):
     A simple pickle-based serializer.
     """
 
-    def dumps(
-        self, response: Response, request: Request, metadata: Metadata
-    ) -> tp.Union[str, bytes]:
+    def dumps(self, response: Response, request: Request, metadata: Metadata) -> tp.Union[str, bytes]:
         """
         Dumps the HTTP response and its HTTP request.
 
@@ -66,27 +60,17 @@ class PickleSerializer(BaseSerializer):
             status=response.status,
             headers=response.headers,
             content=response.content,
-            extensions={
-                key: value
-                for key, value in response.extensions.items()
-                if key in KNOWN_RESPONSE_EXTENSIONS
-            },
+            extensions={key: value for key, value in response.extensions.items() if key in KNOWN_RESPONSE_EXTENSIONS},
         )
         clone_request = Request(
             method=request.method,
             url=normalized_url(request.url),
             headers=request.headers,
-            extensions={
-                key: value
-                for key, value in request.extensions.items()
-                if key in KNOWN_REQUEST_EXTENSIONS
-            },
+            extensions={key: value for key, value in request.extensions.items() if key in KNOWN_REQUEST_EXTENSIONS},
         )
         return pickle.dumps((clone_response, clone_request, metadata))
 
-    def loads(
-        self, data: tp.Union[str, bytes]
-    ) -> tp.Tuple[Response, Request, Metadata]:
+    def loads(self, data: tp.Union[str, bytes]) -> tp.Tuple[Response, Request, Metadata]:
         """
         Loads the HTTP response and its HTTP request from serialized data.
 
@@ -106,9 +90,7 @@ class PickleSerializer(BaseSerializer):
 class JSONSerializer(BaseSerializer):
     """A simple json-based serializer."""
 
-    def dumps(
-        self, response: Response, request: Request, metadata: Metadata
-    ) -> tp.Union[str, bytes]:
+    def dumps(self, response: Response, request: Request, metadata: Metadata) -> tp.Union[str, bytes]:
         """
         Dumps the HTTP response and its HTTP request.
 
@@ -124,8 +106,7 @@ class JSONSerializer(BaseSerializer):
         response_dict = {
             "status": response.status,
             "headers": [
-                (key.decode(HEADERS_ENCODING), value.decode(HEADERS_ENCODING))
-                for key, value in response.headers
+                (key.decode(HEADERS_ENCODING), value.decode(HEADERS_ENCODING)) for key, value in response.headers
             ],
             "content": base64.b64encode(response.content).decode("ascii"),
             "extensions": {
@@ -139,14 +120,9 @@ class JSONSerializer(BaseSerializer):
             "method": request.method.decode("ascii"),
             "url": normalized_url(request.url),
             "headers": [
-                (key.decode(HEADERS_ENCODING), value.decode(HEADERS_ENCODING))
-                for key, value in request.headers
+                (key.decode(HEADERS_ENCODING), value.decode(HEADERS_ENCODING)) for key, value in request.headers
             ],
-            "extensions": {
-                key: value
-                for key, value in request.extensions.items()
-                if key in KNOWN_REQUEST_EXTENSIONS
-            },
+            "extensions": {key: value for key, value in request.extensions.items() if key in KNOWN_REQUEST_EXTENSIONS},
         }
 
         metadata_dict = {
@@ -163,9 +139,7 @@ class JSONSerializer(BaseSerializer):
 
         return json.dumps(full_json, indent=4)
 
-    def loads(
-        self, data: tp.Union[str, bytes]
-    ) -> tp.Tuple[Response, Request, Metadata]:
+    def loads(self, data: tp.Union[str, bytes]) -> tp.Tuple[Response, Request, Metadata]:
         """
         Loads the HTTP response and its HTTP request from serialized data.
 
@@ -203,13 +177,10 @@ class JSONSerializer(BaseSerializer):
             method=request_dict["method"],
             url=request_dict["url"],
             headers=[
-                (key.encode(HEADERS_ENCODING), value.encode(HEADERS_ENCODING))
-                for key, value in request_dict["headers"]
+                (key.encode(HEADERS_ENCODING), value.encode(HEADERS_ENCODING)) for key, value in request_dict["headers"]
             ],
             extensions={
-                key: value
-                for key, value in request_dict["extensions"].items()
-                if key in KNOWN_REQUEST_EXTENSIONS
+                key: value for key, value in request_dict["extensions"].items() if key in KNOWN_REQUEST_EXTENSIONS
             },
         )
 
@@ -229,9 +200,7 @@ class JSONSerializer(BaseSerializer):
 class YAMLSerializer(BaseSerializer):
     """A simple yaml-based serializer."""
 
-    def dumps(
-        self, response: Response, request: Request, metadata: Metadata
-    ) -> tp.Union[str, bytes]:
+    def dumps(self, response: Response, request: Request, metadata: Metadata) -> tp.Union[str, bytes]:
         """
         Dumps the HTTP response and its HTTP request.
 
@@ -255,8 +224,7 @@ class YAMLSerializer(BaseSerializer):
         response_dict = {
             "status": response.status,
             "headers": [
-                (key.decode(HEADERS_ENCODING), value.decode(HEADERS_ENCODING))
-                for key, value in response.headers
+                (key.decode(HEADERS_ENCODING), value.decode(HEADERS_ENCODING)) for key, value in response.headers
             ],
             "content": base64.b64encode(response.content).decode("ascii"),
             "extensions": {
@@ -270,14 +238,9 @@ class YAMLSerializer(BaseSerializer):
             "method": request.method.decode("ascii"),
             "url": normalized_url(request.url),
             "headers": [
-                (key.decode(HEADERS_ENCODING), value.decode(HEADERS_ENCODING))
-                for key, value in request.headers
+                (key.decode(HEADERS_ENCODING), value.decode(HEADERS_ENCODING)) for key, value in request.headers
             ],
-            "extensions": {
-                key: value
-                for key, value in request.extensions.items()
-                if key in KNOWN_REQUEST_EXTENSIONS
-            },
+            "extensions": {key: value for key, value in request.extensions.items() if key in KNOWN_REQUEST_EXTENSIONS},
         }
 
         metadata_dict = {
@@ -294,9 +257,7 @@ class YAMLSerializer(BaseSerializer):
 
         return yaml.safe_dump(full_json, sort_keys=False)
 
-    def loads(
-        self, data: tp.Union[str, bytes]
-    ) -> tp.Tuple[Response, Request, Metadata]:
+    def loads(self, data: tp.Union[str, bytes]) -> tp.Tuple[Response, Request, Metadata]:
         """
         Loads the HTTP response and its HTTP request from serialized data.
 
@@ -343,13 +304,10 @@ class YAMLSerializer(BaseSerializer):
             method=request_dict["method"],
             url=request_dict["url"],
             headers=[
-                (key.encode(HEADERS_ENCODING), value.encode(HEADERS_ENCODING))
-                for key, value in request_dict["headers"]
+                (key.encode(HEADERS_ENCODING), value.encode(HEADERS_ENCODING)) for key, value in request_dict["headers"]
             ],
             extensions={
-                key: value
-                for key, value in request_dict["extensions"].items()
-                if key in KNOWN_REQUEST_EXTENSIONS
+                key: value for key, value in request_dict["extensions"].items() if key in KNOWN_REQUEST_EXTENSIONS
             },
         )
 

--- a/hishel/_sync/_mock.py
+++ b/hishel/_sync/_mock.py
@@ -12,9 +12,7 @@ __all__ = ("MockConnectionPool", "MockTransport")
 
 
 class MockConnectionPool(RequestInterface):
-    def handle_request(
-        self, request: httpcore.Request
-    ) -> httpcore.Response:
+    def handle_request(self, request: httpcore.Request) -> httpcore.Response:
         return self.mocked_responses.pop(0)
 
     def add_responses(self, responses: tp.List[httpcore.Response]) -> None:

--- a/hishel/_sync/_pool.py
+++ b/hishel/_sync/_pool.py
@@ -39,11 +39,7 @@ class CacheConnectionPool(RequestInterface):
         controller: tp.Optional[Controller] = None,
     ) -> None:
         self._pool = pool
-        self._storage = (
-            storage
-            if storage is not None
-            else FileStorage(serializer=JSONSerializer())
-        )
+        self._storage = storage if storage is not None else FileStorage(serializer=JSONSerializer())
         self._controller = controller if controller is not None else Controller()
 
     def handle_request(self, request: Request) -> Response:
@@ -59,9 +55,7 @@ class CacheConnectionPool(RequestInterface):
         key = generate_key(request)
         stored_data = self._storage.retreive(key)
 
-        request_cache_control = parse_cache_control(
-            extract_header_values_decoded(request.headers, b"Cache-Control")
-        )
+        request_cache_control = parse_cache_control(extract_header_values_decoded(request.headers, b"Cache-Control"))
 
         if request_cache_control.only_if_cached and not stored_data:
             return generate_504()
@@ -100,9 +94,7 @@ class CacheConnectionPool(RequestInterface):
                 try:
                     response = self._pool.handle_request(res)
                 except ConnectError:
-                    if self._controller._allow_stale and allowed_stale(
-                        response=stored_resposne
-                    ):
+                    if self._controller._allow_stale and allowed_stale(response=stored_resposne):
                         stored_resposne.extensions["from_cache"] = True  # type: ignore[index]
                         stored_resposne.extensions["cache_metadata"] = metadata  # type: ignore[index]
                         return stored_resposne
@@ -114,9 +106,7 @@ class CacheConnectionPool(RequestInterface):
 
                 full_response.read()
                 metadata["number_of_uses"] += response.status == 304
-                self._storage.store(
-                    key, response=full_response, request=request, metadata=metadata
-                )
+                self._storage.store(key, response=full_response, request=request, metadata=metadata)
                 full_response.extensions["from_cache"] = response.status == 304  # type: ignore[index]
                 if full_response.extensions["from_cache"]:
                     full_response.extensions["cache_metadata"] = metadata  # type: ignore[index]
@@ -126,12 +116,8 @@ class CacheConnectionPool(RequestInterface):
 
         if self._controller.is_cachable(request=request, response=response):
             response.read()
-            metadata = Metadata(
-                cache_key=key, created_at=datetime.datetime.utcnow(), number_of_uses=0
-            )
-            self._storage.store(
-                key, response=response, request=request, metadata=metadata
-            )
+            metadata = Metadata(cache_key=key, created_at=datetime.datetime.utcnow(), number_of_uses=0)
+            self._storage.store(key, response=response, request=request, metadata=metadata)
 
         response.extensions["from_cache"] = False  # type: ignore[index]
         return response

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -35,14 +35,10 @@ class BaseStorage:
         self._serializer = serializer or JSONSerializer()
         self._ttl = ttl
 
-    def store(
-        self, key: str, response: Response, request: Request, metadata: Metadata
-    ) -> None:
+    def store(self, key: str, response: Response, request: Request, metadata: Metadata) -> None:
         raise NotImplementedError()
 
-    def retreive(
-        self, key: str
-    ) -> tp.Optional[tp.Tuple[Response, Request, Metadata]]:
+    def retreive(self, key: str) -> tp.Optional[tp.Tuple[Response, Request, Metadata]]:
         raise NotImplementedError()
 
     def close(self) -> None:
@@ -69,9 +65,7 @@ class FileStorage(BaseStorage):
     ) -> None:
         super().__init__(serializer, ttl)
 
-        self._base_path = (
-            Path(base_path) if base_path is not None else Path(".cache/hishel")
-        )
+        self._base_path = Path(base_path) if base_path is not None else Path(".cache/hishel")
 
         if not self._base_path.is_dir():
             self._base_path.mkdir(parents=True)
@@ -79,9 +73,7 @@ class FileStorage(BaseStorage):
         self._file_manager = FileManager(is_binary=self._serializer.is_binary)
         self._lock = Lock()
 
-    def store(
-        self, key: str, response: Response, request: Request, metadata: Metadata
-    ) -> None:
+    def store(self, key: str, response: Response, request: Request, metadata: Metadata) -> None:
         """
         Stores the response in the cache.
 
@@ -99,15 +91,11 @@ class FileStorage(BaseStorage):
         with self._lock:
             self._file_manager.write_to(
                 str(response_path),
-                self._serializer.dumps(
-                    response=response, request=request, metadata=metadata
-                ),
+                self._serializer.dumps(response=response, request=request, metadata=metadata),
             )
         self._remove_expired_caches()
 
-    def retreive(
-        self, key: str
-    ) -> tp.Optional[tp.Tuple[Response, Request, Metadata]]:
+    def retreive(self, key: str) -> tp.Optional[tp.Tuple[Response, Request, Metadata]]:
         """
         Retreives the response from the cache using his key.
 
@@ -122,9 +110,7 @@ class FileStorage(BaseStorage):
         self._remove_expired_caches()
         with self._lock:
             if response_path.exists():
-                return self._serializer.loads(
-                    self._file_manager.read_from(str(response_path))
-                )
+                return self._serializer.loads(self._file_manager.read_from(str(response_path)))
         return None
 
     def close(self) -> None:
@@ -179,9 +165,7 @@ class SQLiteStorage(BaseStorage):
         with self._setup_lock:
             if not self._setup_completed:
                 if not self._connection:  # pragma: no cover
-                    self._connection = sqlite3.connect(
-                        ".hishel.sqlite", check_same_thread=False
-                    )
+                    self._connection = sqlite3.connect(".hishel.sqlite", check_same_thread=False)
                 self._connection.execute(
                     (
                         "CREATE TABLE IF NOT EXISTS cache(key TEXT, data BLOB, "
@@ -191,9 +175,7 @@ class SQLiteStorage(BaseStorage):
                 self._connection.commit()
                 self._setup_completed = True
 
-    def store(
-        self, key: str, response: Response, request: Request, metadata: Metadata
-    ) -> None:
+    def store(self, key: str, response: Response, request: Request, metadata: Metadata) -> None:
         """
         Stores the response in the cache.
 
@@ -212,18 +194,12 @@ class SQLiteStorage(BaseStorage):
 
         with self._lock:
             self._connection.execute("DELETE FROM cache WHERE key = ?", [key])
-            serialized_response = self._serializer.dumps(
-                response=response, request=request, metadata=metadata
-            )
-            self._connection.execute(
-                "INSERT INTO cache(key, data) VALUES(?, ?)", [key, serialized_response]
-            )
+            serialized_response = self._serializer.dumps(response=response, request=request, metadata=metadata)
+            self._connection.execute("INSERT INTO cache(key, data) VALUES(?, ?)", [key, serialized_response])
             self._connection.commit()
         self._remove_expired_caches()
 
-    def retreive(
-        self, key: str
-    ) -> tp.Optional[tp.Tuple[Response, Request, Metadata]]:
+    def retreive(self, key: str) -> tp.Optional[tp.Tuple[Response, Request, Metadata]]:
         """
         Retreives the response from the cache using his key.
 
@@ -238,9 +214,7 @@ class SQLiteStorage(BaseStorage):
 
         self._remove_expired_caches()
         with self._lock:
-            cursor = self._connection.execute(
-                "SELECT data FROM cache WHERE key = ?", [key]
-            )
+            cursor = self._connection.execute("SELECT data FROM cache WHERE key = ?", [key])
             row = cursor.fetchone()
             if row is None:
                 return None
@@ -297,9 +271,7 @@ class RedisStorage(BaseStorage):
         else:  # pragma: no cover
             self._client = client
 
-    def store(
-        self, key: str, response: Response, request: Request, metadata: Metadata
-    ) -> None:
+    def store(self, key: str, response: Response, request: Request, metadata: Metadata) -> None:
         """
         Stores the response in the cache.
 
@@ -314,15 +286,11 @@ class RedisStorage(BaseStorage):
         """
         self._client.set(
             key,
-            self._serializer.dumps(
-                response=response, request=request, metadata=metadata
-            ),
+            self._serializer.dumps(response=response, request=request, metadata=metadata),
             ex=self._ttl,
         )
 
-    def retreive(
-        self, key: str
-    ) -> tp.Optional[tp.Tuple[Response, Request, Metadata]]:
+    def retreive(self, key: str) -> tp.Optional[tp.Tuple[Response, Request, Metadata]]:
         """
         Retreives the response from the cache using his key.
 

--- a/hishel/_sync/_transports.py
+++ b/hishel/_sync/_transports.py
@@ -60,11 +60,7 @@ class CacheTransport(httpx.BaseTransport):
         controller: tp.Optional[Controller] = None,
     ) -> None:
         self._transport = transport
-        self._storage = (
-            storage
-            if storage is not None
-            else FileStorage(serializer=JSONSerializer())
-        )
+        self._storage = storage if storage is not None else FileStorage(serializer=JSONSerializer())
         self._controller = controller if controller is not None else Controller()
 
     def handle_request(self, request: Request) -> Response:
@@ -141,22 +137,16 @@ class CacheTransport(httpx.BaseTransport):
                     stream=CacheStream(res.stream),
                 )
                 try:
-                    response = self._transport.handle_request(
-                        revalidation_request
-                    )
+                    response = self._transport.handle_request(revalidation_request)
                 except ConnectError:
-                    if self._controller._allow_stale and allowed_stale(
-                        response=stored_resposne
-                    ):
+                    if self._controller._allow_stale and allowed_stale(response=stored_resposne):
                         stored_resposne.read()
                         stored_resposne.extensions["from_cache"] = True  # type: ignore[index]
                         stored_resposne.extensions["cache_metadata"] = metadata  # type: ignore[index]
                         return Response(
                             status_code=stored_resposne.status,
                             headers=stored_resposne.headers,
-                            stream=CacheStream(
-                                fake_stream(stored_resposne.content)
-                            ),
+                            stream=CacheStream(fake_stream(stored_resposne.content)),
                             extensions=stored_resposne.extensions,
                         )
                     raise  # pragma: no cover
@@ -209,12 +199,8 @@ class CacheTransport(httpx.BaseTransport):
         httpcore_response.read()
         httpcore_response.close()
 
-        if self._controller.is_cachable(
-            request=httpcore_request, response=httpcore_response
-        ):
-            metadata = Metadata(
-                cache_key=key, created_at=datetime.datetime.utcnow(), number_of_uses=0
-            )
+        if self._controller.is_cachable(request=httpcore_request, response=httpcore_response):
+            metadata = Metadata(cache_key=key, created_at=datetime.datetime.utcnow(), number_of_uses=0)
             self._storage.store(
                 key,
                 response=httpcore_response,

--- a/hishel/_utils.py
+++ b/hishel/_utils.py
@@ -66,15 +66,11 @@ def extract_header_values(
 def extract_header_values_decoded(
     headers: tp.List[tp.Tuple[bytes, bytes]], header_key: bytes, single: bool = False
 ) -> tp.List[str]:
-    values = extract_header_values(
-        headers=headers, header_key=header_key, single=single
-    )
+    values = extract_header_values(headers=headers, header_key=header_key, single=single)
     return [value.decode(HEADERS_ENCODING) for value in values]
 
 
-def header_presents(
-    headers: tp.List[tp.Tuple[bytes, bytes]], header_key: bytes
-) -> bool:
+def header_presents(headers: tp.List[tp.Tuple[bytes, bytes]], header_key: bytes) -> bool:
     return bool(extract_header_values(headers, header_key, single=True))
 
 

--- a/scripts/check
+++ b/scripts/check
@@ -1,6 +1,6 @@
 #! /bin/bash -ex
 
-black --check --diff --exclude '/(_sync)/' tests hishel
+ruff format tests hishel --diff
 ruff tests hishel
 mypy tests hishel
 python unasync.py check

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,5 +1,5 @@
 #! /bin/bash -ex
 
-black --exclude '/(_sync)/' hishel tests
+ruff format hishel tests
 ruff --fix hishel tests
 python unasync.py

--- a/tests/_async/test_client.py
+++ b/tests/_async/test_client.py
@@ -7,9 +7,7 @@ import hishel
 @pytest.mark.anyio
 async def test_client_301():
     async with hishel.MockAsyncTransport() as transport:
-        transport.add_responses(
-            [httpx.Response(301, headers=[(b"Location", b"https://example.com")])]
-        )
+        transport.add_responses([httpx.Response(301, headers=[(b"Location", b"https://example.com")])])
         async with hishel.AsyncCacheClient(transport=transport) as client:
             await client.request(
                 "GET",

--- a/tests/_async/test_pool.py
+++ b/tests/_async/test_pool.py
@@ -9,9 +9,7 @@ from hishel._utils import extract_header_values, header_presents
 @pytest.mark.anyio
 async def test_pool_301(use_temp_dir):
     async with hishel.MockAsyncConnectionPool() as pool:
-        pool.add_responses(
-            [httpcore.Response(301, headers=[(b"Location", b"https://example.com")])]
-        )
+        pool.add_responses([httpcore.Response(301, headers=[(b"Location", b"https://example.com")])])
         async with hishel.AsyncCacheConnectionPool(pool=pool) as cache_pool:
             await cache_pool.request("GET", "https://www.example.com")
             response = await cache_pool.request("GET", "https://www.example.com")
@@ -49,10 +47,7 @@ async def test_pool_response_validation(use_temp_dir):
         assert response.status == 200
         assert response.extensions["from_cache"]
         assert header_presents(response.headers, b"Content-Type")
-        assert (
-            extract_header_values(response.headers, b"Content-Type", single=True)[0]
-            == b"application/json"
-        )
+        assert extract_header_values(response.headers, b"Content-Type", single=True)[0] == b"application/json"
         assert await response.aread() == b"test"
 
 
@@ -78,9 +73,7 @@ async def test_pool_stale_response(use_temp_dir):
                 ),
             ]
         )
-        async with hishel.AsyncCacheConnectionPool(
-            pool=pool, controller=controller
-        ) as cache_pool:
+        async with hishel.AsyncCacheConnectionPool(pool=pool, controller=controller) as cache_pool:
             await cache_pool.request("GET", "https://www.example.com")
             response = await cache_pool.request("GET", "https://www.example.com")
             assert not response.extensions["from_cache"]
@@ -109,9 +102,7 @@ async def test_pool_stale_response_with_connecterror(use_temp_dir):
                 ),
             ]
         )
-        async with hishel.AsyncCacheConnectionPool(
-            pool=pool, controller=controller
-        ) as cache_pool:
+        async with hishel.AsyncCacheConnectionPool(pool=pool, controller=controller) as cache_pool:
             await cache_pool.request("GET", "https://www.example.com")
             response = await cache_pool.request("GET", "https://www.example.com")
             assert response.extensions["from_cache"]
@@ -122,9 +113,7 @@ async def test_pool_with_only_if_cached_directive_without_stored_response(use_te
     controller = hishel.Controller()
 
     async with hishel.MockAsyncConnectionPool() as pool:
-        async with hishel.AsyncCacheConnectionPool(
-            pool=pool, controller=controller
-        ) as cache_pool:
+        async with hishel.AsyncCacheConnectionPool(pool=pool, controller=controller) as cache_pool:
             response = await cache_pool.request(
                 "GET",
                 "https://www.example.com",
@@ -150,9 +139,7 @@ async def test_pool_with_only_if_cached_directive_with_stored_response(use_temp_
                 ),
             ]
         )
-        async with hishel.AsyncCacheConnectionPool(
-            pool=pool, controller=controller
-        ) as cache_pool:
+        async with hishel.AsyncCacheConnectionPool(pool=pool, controller=controller) as cache_pool:
             await cache_pool.request("GET", "https://www.example.com")
             response = await cache_pool.request(
                 "GET",

--- a/tests/_async/test_storages.py
+++ b/tests/_async/test_storages.py
@@ -8,9 +8,7 @@ from hishel import AsyncFileStorage, AsyncRedisStorage, AsyncSQLiteStorage
 from hishel._serializers import Metadata
 from hishel._utils import asleep, generate_key
 
-dummy_metadata = Metadata(
-    cache_key="test", number_of_uses=0, created_at=datetime.datetime.utcnow()
-)
+dummy_metadata = Metadata(cache_key="test", number_of_uses=0, created_at=datetime.datetime.utcnow())
 
 
 def is_redis_down() -> bool:
@@ -34,9 +32,7 @@ async def test_filestorage(use_temp_dir):
     response = Response(200, headers=[], content=b"test")
     await response.aread()
 
-    await storage.store(
-        key, response=response, request=request, metadata=dummy_metadata
-    )
+    await storage.store(key, response=response, request=request, metadata=dummy_metadata)
 
     stored_data = await storage.retreive(key)
     assert stored_data is not None
@@ -61,9 +57,7 @@ async def test_redisstorage():
     response = Response(200, headers=[], content=b"test")
     await response.aread()
 
-    await storage.store(
-        key, response=response, request=request, metadata=dummy_metadata
-    )
+    await storage.store(key, response=response, request=request, metadata=dummy_metadata)
 
     stored_data = await storage.retreive(key)
     assert stored_data is not None
@@ -86,9 +80,7 @@ async def test_sqlitestorage():
     response = Response(200, headers=[], content=b"test")
     await response.aread()
 
-    await storage.store(
-        key, response=response, request=request, metadata=dummy_metadata
-    )
+    await storage.store(key, response=response, request=request, metadata=dummy_metadata)
 
     stored_data = await storage.retreive(key)
     assert stored_data is not None
@@ -112,14 +104,10 @@ async def test_filestorage_expired():
     response = Response(200, headers=[], content=b"test")
     await response.aread()
 
-    await storage.store(
-        first_key, response=response, request=first_request, metadata=dummy_metadata
-    )
+    await storage.store(first_key, response=response, request=first_request, metadata=dummy_metadata)
 
     await asleep(2)
-    await storage.store(
-        second_key, response=response, request=second_request, metadata=dummy_metadata
-    )
+    await storage.store(second_key, response=response, request=second_request, metadata=dummy_metadata)
 
     assert await storage.retreive(first_key) is None
 
@@ -138,14 +126,10 @@ async def test_redisstorage_expired():
     response = Response(200, headers=[], content=b"test")
     await response.aread()
 
-    await storage.store(
-        first_key, response=response, request=first_request, metadata=dummy_metadata
-    )
+    await storage.store(first_key, response=response, request=first_request, metadata=dummy_metadata)
 
     await asleep(2)
-    await storage.store(
-        second_key, response=response, request=second_request, metadata=dummy_metadata
-    )
+    await storage.store(second_key, response=response, request=second_request, metadata=dummy_metadata)
 
     assert await storage.retreive(first_key) is None
 
@@ -162,13 +146,9 @@ async def test_sqlite_expired():
     response = Response(200, headers=[], content=b"test")
     await response.aread()
 
-    await storage.store(
-        first_key, response=response, request=first_request, metadata=dummy_metadata
-    )
+    await storage.store(first_key, response=response, request=first_request, metadata=dummy_metadata)
 
     await asleep(2)
-    await storage.store(
-        second_key, response=response, request=second_request, metadata=dummy_metadata
-    )
+    await storage.store(second_key, response=response, request=second_request, metadata=dummy_metadata)
 
     assert await storage.retreive(first_key) is None

--- a/tests/_async/test_transport.py
+++ b/tests/_async/test_transport.py
@@ -7,9 +7,7 @@ import hishel
 @pytest.mark.anyio
 async def test_transport_301(use_temp_dir):
     async with hishel.MockAsyncTransport() as transport:
-        transport.add_responses(
-            [httpx.Response(301, headers=[(b"Location", b"https://example.com")])]
-        )
+        transport.add_responses([httpx.Response(301, headers=[(b"Location", b"https://example.com")])])
         async with hishel.AsyncCacheTransport(transport=transport) as cache_transport:
             request = httpx.Request("GET", "https://www.example.com")
 
@@ -76,9 +74,7 @@ async def test_transport_stale_response(use_temp_dir):
                 ),
             ]
         )
-        async with hishel.AsyncCacheTransport(
-            transport=transport, controller=controller
-        ) as cache_transport:
+        async with hishel.AsyncCacheTransport(transport=transport, controller=controller) as cache_transport:
             request = httpx.Request("GET", "https://www.example.com")
             await cache_transport.handle_async_request(request)
             response = await cache_transport.handle_async_request(request)
@@ -115,9 +111,7 @@ async def test_transport_stale_response_with_connecterror(use_temp_dir):
                 ),
             ]
         )
-        async with hishel.AsyncCacheTransport(
-            transport=transport, controller=controller
-        ) as cache_transport:
+        async with hishel.AsyncCacheTransport(transport=transport, controller=controller) as cache_transport:
             request = httpx.Request("GET", "https://www.example.com")
             await cache_transport.handle_async_request(request)
             response = await cache_transport.handle_async_request(request)
@@ -131,9 +125,7 @@ async def test_transport_with_only_if_cached_directive_without_stored_response(
     controller = hishel.Controller()
 
     async with hishel.MockAsyncTransport() as transport:
-        async with hishel.AsyncCacheTransport(
-            transport=transport, controller=controller
-        ) as cache_transport:
+        async with hishel.AsyncCacheTransport(transport=transport, controller=controller) as cache_transport:
             response = await cache_transport.handle_async_request(
                 httpx.Request(
                     "GET",
@@ -163,12 +155,8 @@ async def test_transport_with_only_if_cached_directive_with_stored_response(
                 ),
             ]
         )
-        async with hishel.AsyncCacheTransport(
-            transport=transport, controller=controller
-        ) as cache_transport:
-            await cache_transport.handle_async_request(
-                httpx.Request("GET", "https://www.example.com")
-            )
+        async with hishel.AsyncCacheTransport(transport=transport, controller=controller) as cache_transport:
+            await cache_transport.handle_async_request(httpx.Request("GET", "https://www.example.com"))
             response = await cache_transport.handle_async_request(
                 httpx.Request(
                     "GET",

--- a/tests/_sync/test_client.py
+++ b/tests/_sync/test_client.py
@@ -7,9 +7,7 @@ import hishel
 
 def test_client_301():
     with hishel.MockTransport() as transport:
-        transport.add_responses(
-            [httpx.Response(301, headers=[(b"Location", b"https://example.com")])]
-        )
+        transport.add_responses([httpx.Response(301, headers=[(b"Location", b"https://example.com")])])
         with hishel.CacheClient(transport=transport) as client:
             client.request(
                 "GET",

--- a/tests/_sync/test_pool.py
+++ b/tests/_sync/test_pool.py
@@ -9,9 +9,7 @@ from hishel._utils import extract_header_values, header_presents
 
 def test_pool_301(use_temp_dir):
     with hishel.MockConnectionPool() as pool:
-        pool.add_responses(
-            [httpcore.Response(301, headers=[(b"Location", b"https://example.com")])]
-        )
+        pool.add_responses([httpcore.Response(301, headers=[(b"Location", b"https://example.com")])])
         with hishel.CacheConnectionPool(pool=pool) as cache_pool:
             cache_pool.request("GET", "https://www.example.com")
             response = cache_pool.request("GET", "https://www.example.com")
@@ -49,10 +47,7 @@ def test_pool_response_validation(use_temp_dir):
         assert response.status == 200
         assert response.extensions["from_cache"]
         assert header_presents(response.headers, b"Content-Type")
-        assert (
-            extract_header_values(response.headers, b"Content-Type", single=True)[0]
-            == b"application/json"
-        )
+        assert extract_header_values(response.headers, b"Content-Type", single=True)[0] == b"application/json"
         assert response.read() == b"test"
 
 
@@ -78,9 +73,7 @@ def test_pool_stale_response(use_temp_dir):
                 ),
             ]
         )
-        with hishel.CacheConnectionPool(
-            pool=pool, controller=controller
-        ) as cache_pool:
+        with hishel.CacheConnectionPool(pool=pool, controller=controller) as cache_pool:
             cache_pool.request("GET", "https://www.example.com")
             response = cache_pool.request("GET", "https://www.example.com")
             assert not response.extensions["from_cache"]
@@ -109,9 +102,7 @@ def test_pool_stale_response_with_connecterror(use_temp_dir):
                 ),
             ]
         )
-        with hishel.CacheConnectionPool(
-            pool=pool, controller=controller
-        ) as cache_pool:
+        with hishel.CacheConnectionPool(pool=pool, controller=controller) as cache_pool:
             cache_pool.request("GET", "https://www.example.com")
             response = cache_pool.request("GET", "https://www.example.com")
             assert response.extensions["from_cache"]
@@ -122,9 +113,7 @@ def test_pool_with_only_if_cached_directive_without_stored_response(use_temp_dir
     controller = hishel.Controller()
 
     with hishel.MockConnectionPool() as pool:
-        with hishel.CacheConnectionPool(
-            pool=pool, controller=controller
-        ) as cache_pool:
+        with hishel.CacheConnectionPool(pool=pool, controller=controller) as cache_pool:
             response = cache_pool.request(
                 "GET",
                 "https://www.example.com",
@@ -150,9 +139,7 @@ def test_pool_with_only_if_cached_directive_with_stored_response(use_temp_dir):
                 ),
             ]
         )
-        with hishel.CacheConnectionPool(
-            pool=pool, controller=controller
-        ) as cache_pool:
+        with hishel.CacheConnectionPool(pool=pool, controller=controller) as cache_pool:
             cache_pool.request("GET", "https://www.example.com")
             response = cache_pool.request(
                 "GET",

--- a/tests/_sync/test_storages.py
+++ b/tests/_sync/test_storages.py
@@ -8,9 +8,7 @@ from hishel import FileStorage, RedisStorage, SQLiteStorage
 from hishel._serializers import Metadata
 from hishel._utils import sleep, generate_key
 
-dummy_metadata = Metadata(
-    cache_key="test", number_of_uses=0, created_at=datetime.datetime.utcnow()
-)
+dummy_metadata = Metadata(cache_key="test", number_of_uses=0, created_at=datetime.datetime.utcnow())
 
 
 def is_redis_down() -> bool:
@@ -34,9 +32,7 @@ def test_filestorage(use_temp_dir):
     response = Response(200, headers=[], content=b"test")
     response.read()
 
-    storage.store(
-        key, response=response, request=request, metadata=dummy_metadata
-    )
+    storage.store(key, response=response, request=request, metadata=dummy_metadata)
 
     stored_data = storage.retreive(key)
     assert stored_data is not None
@@ -61,9 +57,7 @@ def test_redisstorage():
     response = Response(200, headers=[], content=b"test")
     response.read()
 
-    storage.store(
-        key, response=response, request=request, metadata=dummy_metadata
-    )
+    storage.store(key, response=response, request=request, metadata=dummy_metadata)
 
     stored_data = storage.retreive(key)
     assert stored_data is not None
@@ -86,9 +80,7 @@ def test_sqlitestorage():
     response = Response(200, headers=[], content=b"test")
     response.read()
 
-    storage.store(
-        key, response=response, request=request, metadata=dummy_metadata
-    )
+    storage.store(key, response=response, request=request, metadata=dummy_metadata)
 
     stored_data = storage.retreive(key)
     assert stored_data is not None
@@ -112,14 +104,10 @@ def test_filestorage_expired():
     response = Response(200, headers=[], content=b"test")
     response.read()
 
-    storage.store(
-        first_key, response=response, request=first_request, metadata=dummy_metadata
-    )
+    storage.store(first_key, response=response, request=first_request, metadata=dummy_metadata)
 
     sleep(2)
-    storage.store(
-        second_key, response=response, request=second_request, metadata=dummy_metadata
-    )
+    storage.store(second_key, response=response, request=second_request, metadata=dummy_metadata)
 
     assert storage.retreive(first_key) is None
 
@@ -138,14 +126,10 @@ def test_redisstorage_expired():
     response = Response(200, headers=[], content=b"test")
     response.read()
 
-    storage.store(
-        first_key, response=response, request=first_request, metadata=dummy_metadata
-    )
+    storage.store(first_key, response=response, request=first_request, metadata=dummy_metadata)
 
     sleep(2)
-    storage.store(
-        second_key, response=response, request=second_request, metadata=dummy_metadata
-    )
+    storage.store(second_key, response=response, request=second_request, metadata=dummy_metadata)
 
     assert storage.retreive(first_key) is None
 
@@ -162,13 +146,9 @@ def test_sqlite_expired():
     response = Response(200, headers=[], content=b"test")
     response.read()
 
-    storage.store(
-        first_key, response=response, request=first_request, metadata=dummy_metadata
-    )
+    storage.store(first_key, response=response, request=first_request, metadata=dummy_metadata)
 
     sleep(2)
-    storage.store(
-        second_key, response=response, request=second_request, metadata=dummy_metadata
-    )
+    storage.store(second_key, response=response, request=second_request, metadata=dummy_metadata)
 
     assert storage.retreive(first_key) is None

--- a/tests/_sync/test_transport.py
+++ b/tests/_sync/test_transport.py
@@ -7,9 +7,7 @@ import hishel
 
 def test_transport_301(use_temp_dir):
     with hishel.MockTransport() as transport:
-        transport.add_responses(
-            [httpx.Response(301, headers=[(b"Location", b"https://example.com")])]
-        )
+        transport.add_responses([httpx.Response(301, headers=[(b"Location", b"https://example.com")])])
         with hishel.CacheTransport(transport=transport) as cache_transport:
             request = httpx.Request("GET", "https://www.example.com")
 
@@ -76,9 +74,7 @@ def test_transport_stale_response(use_temp_dir):
                 ),
             ]
         )
-        with hishel.CacheTransport(
-            transport=transport, controller=controller
-        ) as cache_transport:
+        with hishel.CacheTransport(transport=transport, controller=controller) as cache_transport:
             request = httpx.Request("GET", "https://www.example.com")
             cache_transport.handle_request(request)
             response = cache_transport.handle_request(request)
@@ -115,9 +111,7 @@ def test_transport_stale_response_with_connecterror(use_temp_dir):
                 ),
             ]
         )
-        with hishel.CacheTransport(
-            transport=transport, controller=controller
-        ) as cache_transport:
+        with hishel.CacheTransport(transport=transport, controller=controller) as cache_transport:
             request = httpx.Request("GET", "https://www.example.com")
             cache_transport.handle_request(request)
             response = cache_transport.handle_request(request)
@@ -131,9 +125,7 @@ def test_transport_with_only_if_cached_directive_without_stored_response(
     controller = hishel.Controller()
 
     with hishel.MockTransport() as transport:
-        with hishel.CacheTransport(
-            transport=transport, controller=controller
-        ) as cache_transport:
+        with hishel.CacheTransport(transport=transport, controller=controller) as cache_transport:
             response = cache_transport.handle_request(
                 httpx.Request(
                     "GET",
@@ -163,12 +155,8 @@ def test_transport_with_only_if_cached_directive_with_stored_response(
                 ),
             ]
         )
-        with hishel.CacheTransport(
-            transport=transport, controller=controller
-        ) as cache_transport:
-            cache_transport.handle_request(
-                httpx.Request("GET", "https://www.example.com")
-            )
+        with hishel.CacheTransport(transport=transport, controller=controller) as cache_transport:
+            cache_transport.handle_request(httpx.Request("GET", "https://www.example.com"))
             response = cache_transport.handle_request(
                 httpx.Request(
                     "GET",

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -127,9 +127,7 @@ def test_get_heuristic_freshness():
         def now(self) -> int:
             return 1093435200  # Mon, 25 Aug 2003 12:00:00 GMT
 
-    response = Response(
-        status=200, headers=[(b"Last-Modified", "Mon, 25 Aug 2003 12:00:00 GMT")]
-    )
+    response = Response(status=200, headers=[(b"Last-Modified", "Mon, 25 Aug 2003 12:00:00 GMT")])
     assert get_heuristic_freshness(response=response, clock=MockedClock()) == ONE_WEEK
 
 
@@ -145,9 +143,7 @@ def test_get_age():
         def now(self) -> int:
             return 1440590400
 
-    response = Response(
-        status=200, headers=[(b"Date", b"Tue, 25 Aug 2015 12:00:00 GMT")]
-    )
+    response = Response(status=200, headers=[(b"Date", b"Tue, 25 Aug 2015 12:00:00 GMT")])
     age = get_age(response=response, clock=MockedClock())
     assert age == 86400  # One day
 
@@ -221,9 +217,7 @@ def test_make_conditional_request_with_last_modified():
         ],
     )
 
-    response = Response(
-        status=200, headers=[(b"Last-Modified", b"Wed, 21 Oct 2015 07:28:00 GMT")]
-    )
+    response = Response(status=200, headers=[(b"Last-Modified", b"Wed, 21 Oct 2015 07:28:00 GMT")])
 
     controller._make_request_conditional(request=request, response=response)
 
@@ -344,17 +338,11 @@ def test_construct_response_heuristically():
 def test_handle_validation_response_changed():
     controller = Controller()
 
-    old_response = Response(
-        status=200, headers=[(b"old-response", b"true")], content=b"old"
-    )
+    old_response = Response(status=200, headers=[(b"old-response", b"true")], content=b"old")
 
-    new_response = Response(
-        status=200, headers=[(b"new-response", b"true")], content=b"new"
-    )
+    new_response = Response(status=200, headers=[(b"new-response", b"true")], content=b"new")
 
-    response = controller.handle_validation_response(
-        old_response=old_response, new_response=new_response
-    )
+    response = controller.handle_validation_response(old_response=old_response, new_response=new_response)
     response.read()
 
     assert response.headers == [(b"new-response", b"true")]
@@ -364,9 +352,7 @@ def test_handle_validation_response_changed():
 def test_handle_validation_response_not_changed():
     controller = Controller()
 
-    old_response = Response(
-        status=200, headers=[(b"old-response", b"true")], content=b"old"
-    )
+    old_response = Response(status=200, headers=[(b"old-response", b"true")], content=b"old")
 
     new_response = Response(
         status=304,
@@ -374,9 +360,7 @@ def test_handle_validation_response_not_changed():
         content=b"new",
     )
 
-    response = controller.handle_validation_response(
-        old_response=old_response, new_response=new_response
-    )
+    response = controller.handle_validation_response(old_response=old_response, new_response=new_response)
     response.read()
 
     assert response.headers == [(b"old-response", b"true"), (b"new-response", b"false")]
@@ -412,15 +396,11 @@ def test_vary_validation():
 
     controller = Controller()
 
-    assert controller._validate_vary(
-        request=request, response=response, original_request=original_request
-    )
+    assert controller._validate_vary(request=request, response=response, original_request=original_request)
 
     original_request.headers.pop(0)
 
-    assert not controller._validate_vary(
-        request=request, response=response, original_request=original_request
-    )
+    assert not controller._validate_vary(request=request, response=response, original_request=original_request)
 
 
 def test_vary_validation_value_mismatch():
@@ -453,9 +433,7 @@ def test_vary_validation_value_mismatch():
 
     controller = Controller()
 
-    assert not controller._validate_vary(
-        request=request, response=response, original_request=original_request
-    )
+    assert not controller._validate_vary(request=request, response=response, original_request=original_request)
 
 
 def test_vary_validation_value_wildcard():
@@ -488,9 +466,7 @@ def test_vary_validation_value_wildcard():
 
     controller = Controller()
 
-    assert not controller._validate_vary(
-        request=request, response=response, original_request=original_request
-    )
+    assert not controller._validate_vary(request=request, response=response, original_request=original_request)
 
 
 def test_max_age_request_directive():

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -12,9 +12,7 @@ def test_blank_directive():
 
 def test_blank_directive_after_ows_stripping():
     header = [" ,"]
-    with pytest.raises(
-        ParseError, match="The directive should not contain only whitespaces."
-    ):
+    with pytest.raises(ParseError, match="The directive should not contain only whitespaces."):
         parse_cache_control(header)
 
 
@@ -59,9 +57,7 @@ def test_invalid_symbol_in_quoted():
 
 def test_time_field_without_value():
     header = ["max-age"]
-    with pytest.raises(
-        ValidationError, match="The directive 'max_age' necessitates a value."
-    ):
+    with pytest.raises(ValidationError, match="The directive 'max_age' necessitates a value."):
         parse_cache_control(header)
 
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -35,9 +35,7 @@ def test_pickle_serializer_dumps_and_loads():
         created_at=datetime.datetime(year=2003, month=8, day=25, hour=12),
     )
 
-    raw_response = PickleSerializer().dumps(
-        response=response, request=request, metadata=metadata
-    )
+    raw_response = PickleSerializer().dumps(response=response, request=request, metadata=metadata)
 
     response, request, metadata = PickleSerializer().loads(raw_response)
     response.read()
@@ -56,9 +54,7 @@ def test_pickle_serializer_dumps_and_loads():
 
     assert metadata["cache_key"] == "test"
     assert metadata["number_of_uses"] == 0
-    assert metadata["created_at"] == datetime.datetime(
-        year=2003, month=8, day=25, hour=12
-    )
+    assert metadata["created_at"] == datetime.datetime(year=2003, month=8, day=25, hour=12)
 
 
 def test_dict_serializer_dumps():
@@ -85,9 +81,7 @@ def test_dict_serializer_dumps():
         created_at=datetime.datetime(year=2003, month=8, day=25, hour=12),
     )
 
-    full_json = JSONSerializer().dumps(
-        response=response, request=request, metadata=metadata
-    )
+    full_json = JSONSerializer().dumps(response=response, request=request, metadata=metadata)
 
     assert full_json == "\n".join(
         [
@@ -194,9 +188,7 @@ def test_dict_serializer_loads():
 
     assert metadata["cache_key"] == "test"
     assert metadata["number_of_uses"] == 0
-    assert metadata["created_at"] == datetime.datetime(
-        year=2003, month=8, day=25, hour=12
-    )
+    assert metadata["created_at"] == datetime.datetime(year=2003, month=8, day=25, hour=12)
 
 
 def test_yaml_serializer_dumps():
@@ -223,9 +215,7 @@ def test_yaml_serializer_dumps():
         created_at=datetime.datetime(year=2003, month=8, day=25, hour=12),
     )
 
-    full_json = YAMLSerializer().dumps(
-        response=response, request=request, metadata=metadata
-    )
+    full_json = YAMLSerializer().dumps(response=response, request=request, metadata=metadata)
 
     assert full_json == "\n".join(
         [
@@ -304,6 +294,4 @@ def test_yaml_serializer_loads():
 
     assert metadata["cache_key"] == "test"
     assert metadata["number_of_uses"] == 0
-    assert metadata["created_at"] == datetime.datetime(
-        year=2003, month=8, day=25, hour=12
-    )
+    assert metadata["created_at"] == datetime.datetime(year=2003, month=8, day=25, hour=12)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -71,15 +71,11 @@ def test_get_updated_headers():
         (b"Authorization", b"secret-key"),
     ]
 
-    update_headers = get_updated_headers(
-        stored_response_headers=old_headers, new_response_headers=new_headers
-    )
+    update_headers = get_updated_headers(stored_response_headers=old_headers, new_response_headers=new_headers)
 
     assert len(update_headers) == 3
     assert extract_header_values(update_headers, b"Language")[0] == b"am"
-    assert (
-        extract_header_values(update_headers, b"Content-Type")[0] == b"application/json"
-    )
+    assert extract_header_values(update_headers, b"Content-Type")[0] == b"application/json"
     assert extract_header_values(update_headers, b"Authorization")[0] == b"secret-key"
 
 


### PR DESCRIPTION
Replace black with ruff; enforce a 120-line length limit for formatter and linter.

See: https://github.com/encode/httpx/pull/2901 and https://github.com/encode/httpcore/pull/831

