### PR TITLE
Add cache_disabled extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fix issue where freshness cannot be calculated to re-send request. (#104)
 - Add `cache_disabled` extension to temporarily disable the cache (#109)
-- Document response and requests extensions (#109)
 - Update `datetime.datetime.utcnow()` to `datetime.datetime.now(datetime.timezone.utc)` since `datetime.datetime.utcnow()` has been deprecated. (#111)
 
 ## 0.0.17 (6/11/2023) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Fix issue where freshness cannot be calculated to re-send request. (#104)
+- Add `cache_disabled` extension to temporarily disable the cache (#109)
+- Document response and requests extensions (#109)
 
 ## 0.0.17 (6/11/2023) 
 

--- a/docs/advanced/extensions.md
+++ b/docs/advanced/extensions.md
@@ -1,0 +1,20 @@
+---
+icon: material/apps
+---
+
+
+## Response extensions
+
+### from cache
+
+TODO
+
+### cache metadata
+
+TODO
+
+## Request extensions
+
+### cache disabled
+
+TODO

--- a/docs/advanced/extensions.md
+++ b/docs/advanced/extensions.md
@@ -2,6 +2,8 @@
 icon: material/apps
 ---
 
+# Extensions
+
 `HTTPX` provides an extension mechanism to allow additional information 
 to be added to requests and to be returned in responses. `hishel` makes use
 of these extensions to expose some additional cache-related options and metadata.
@@ -11,8 +13,9 @@ using a `hishel` transport.
 
 ## Request extensions
 
-`hishel` currently provides only one extension on requests - `cache_disabled`. This
-extension temporarily disables the cache by passing appropriate RFC911 headers to
+### cache_disabled 
+
+This extension temporarily disables the cache by passing appropriate RFC9111 headers to
 ignore cached responses and to not store incoming responses. For example:
 
 ```python
@@ -25,17 +28,27 @@ This feature is more fully documented in the [User Guide](/userguide/#temporaril
 
 ## Response extensions
 
-`hishel` provides two extensions on responses that provide additional information regarding whether a response was returned from the cache, and additional metadata about the cached response when a response is returned from the cache. 
+### from_cache 
 
-Every response from a `hishel.CacheClient` / `hishel.AsyncCacheClient` will have
-a `from_cache` extension value that will be `True` when the response was retrieved
+Every response from  will have a `from_cache` extension value that will be `True` when the response was retrieved
 from the cache, and `False` when the response was received over the network.
 
-If `from_cache` is `True`, the extensions will also have a dictionary called
-`cache_metadata` with three keys:
- - `cache_key` - The key used in the cache for the response
- - `created_at` - A `datetime.datetime` object indicating when the cached response was created
- - `number_of_uses` - a counter that indicates how many times this response was retrieved from the cache.
+```python
+>>> import hishel
+>>> client = hishel.CacheClient()
+>>> response = client.get("https://www.example.com")
+>>> response.extensions["from_cache"]
+False
+>>> response = client.get("https://www.example.com")
+>>> response.extensions["from_cache"]
+True
+```
+
+### cache_metadata
+
+If `from_cache` is `True`, the response will also include a `cache_metadata` extension with additional information about 
+the response retrieved from the cache. If `from_cache` is `False`, then `cache_metadata` will not
+be present in the response extensions.
 
 Example:
 

--- a/docs/advanced/extensions.md
+++ b/docs/advanced/extensions.md
@@ -2,19 +2,62 @@
 icon: material/apps
 ---
 
-
-## Response extensions
-
-### from cache
-
-TODO
-
-### cache metadata
-
-TODO
+`HTTPX` provides an extension mechanism to allow additional information 
+to be added to requests and to be returned in responses. `hishel` makes use
+of these extensions to expose some additional cache-related options and metadata.
+These extensions are available from either the `hishel.CacheClient` / 
+`hishel.AsyncCacheClient` or a `httpx.Client` / `httpx.AsyncCacheClient`
+using a `hishel` transport.
 
 ## Request extensions
 
-### cache disabled
+`hishel` currently provides only one extension on requests - `cache_disabled`. This
+extension temporarily disables the cache by passing appropriate RFC911 headers to
+ignore cached responses and to not store incoming responses. For example:
 
-TODO
+```python
+>>> import hishel
+>>> client = hishel.CacheClient()
+>>> response = client.get("https://www.example.com/cacheable-endpoint", extensions={"cache_disabled": True})
+
+```
+This feature is more fully documented in the [User Guide](/userguide/#temporarily-disabling-the-cache)
+
+## Response extensions
+
+`hishel` provides two extensions on responses that provide additional information regarding whether a response was returned from the cache, and additional metadata about the cached response when a response is returned from the cache. 
+
+Every response from a `hishel.CacheClient` / `hishel.AsyncCacheClient` will have
+a `from_cache` extension value that will be `True` when the response was retrieved
+from the cache, and `False` when the response was received over the network.
+
+If `from_cache` is `True`, the extensions will also have a dictionary called
+`cache_metadata` with three keys:
+ - `cache_key` - The key used in the cache for the response
+ - `created_at` - A `datetime.datetime` object indicating when the cached response was created
+ - `number_of_uses` - a counter that indicates how many times this response was retrieved from the cache.
+
+Example:
+
+```python
+>>> import hishel
+>>> client = hishel.CacheClient()
+>>> response = client.get("https://www.example.com/cacheable-endpoint")
+>>> response.extensions
+{
+    ... # other extensions
+    "from_cache": False
+}
+>>> response = client.get("https://www.example.com/cacheable-endpoint")
+>>> response.extensions
+{
+    ... # other extensions
+    "from_cache": True
+    "cache_metadata" : {
+        "cache_key': '1a4c648c9a61adf939eef934a73e0cbe',
+        'created_at': datetime.datetime(2020, 1, 1, 0, 0, 0),
+        'number_of_uses': 1,
+    }
+}
+```
+

--- a/hishel/_async/_pool.py
+++ b/hishel/_async/_pool.py
@@ -52,6 +52,9 @@ class AsyncCacheConnectionPool(AsyncRequestInterface):
         :rtype: httpcore.Response
         """
 
+        if request.extensions.get("cache_disabled", False):
+            request.headers.extend([(b"cache-control", b"no-cache"), (b"cache-control", b"max-age=0")])
+
         key = generate_key(request)
         stored_data = await self._storage.retreive(key)
 

--- a/hishel/_async/_transports.py
+++ b/hishel/_async/_transports.py
@@ -73,8 +73,14 @@ class AsyncCacheTransport(httpx.AsyncBaseTransport):
         :rtype: httpx.Response
         """
 
-        if "cache_disabled" in request.extensions and request.extensions["cache_disabled"]:
-            request.headers.update([("Cache-Control", "no-store"), ("Cache-Control", "max-age=0")])
+        if request.extensions.get("cache_disabled", False):
+            request.headers.update(
+                [
+                    ("Cache-Control", "no-store"),
+                    ("Cache-Control", "no-cache"),
+                    *[("cache-control", value) for value in request.headers.get_list("cache-control")],
+                ]
+            )
 
         httpcore_request = httpcore.Request(
             method=request.method,

--- a/hishel/_async/_transports.py
+++ b/hishel/_async/_transports.py
@@ -72,6 +72,10 @@ class AsyncCacheTransport(httpx.AsyncBaseTransport):
         :return: An HTTP response
         :rtype: httpx.Response
         """
+
+        if "cache_disabled" in request.extensions and request.extensions["cache_disabled"]:
+            request.headers.update([("Cache-Control", "no-store"), ("Cache-Control", "max-age=0")])
+
         httpcore_request = httpcore.Request(
             method=request.method,
             url=httpcore.URL(

--- a/hishel/_sync/_pool.py
+++ b/hishel/_sync/_pool.py
@@ -52,6 +52,9 @@ class CacheConnectionPool(RequestInterface):
         :rtype: httpcore.Response
         """
 
+        if request.extensions.get("cache_disabled", False):
+            request.headers.extend([(b"cache-control", b"no-cache"), (b"cache-control", b"max-age=0")])
+
         key = generate_key(request)
         stored_data = self._storage.retreive(key)
 

--- a/hishel/_sync/_transports.py
+++ b/hishel/_sync/_transports.py
@@ -72,6 +72,10 @@ class CacheTransport(httpx.BaseTransport):
         :return: An HTTP response
         :rtype: httpx.Response
         """
+
+        if "cache_disabled" in request.extensions and request.extensions["cache_disabled"]:
+            request.headers.update([("Cache-Control", "no-store"), ("Cache-Control", "max-age=0")])
+
         httpcore_request = httpcore.Request(
             method=request.method,
             url=httpcore.URL(

--- a/hishel/_sync/_transports.py
+++ b/hishel/_sync/_transports.py
@@ -73,8 +73,14 @@ class CacheTransport(httpx.BaseTransport):
         :rtype: httpx.Response
         """
 
-        if "cache_disabled" in request.extensions and request.extensions["cache_disabled"]:
-            request.headers.update([("Cache-Control", "no-store"), ("Cache-Control", "max-age=0")])
+        if request.extensions.get("cache_disabled", False):
+            request.headers.update(
+                [
+                    ("Cache-Control", "no-store"),
+                    ("Cache-Control", "no-cache"),
+                    *[("cache-control", value) for value in request.headers.get_list("cache-control")],
+                ]
+            )
 
         httpcore_request = httpcore.Request(
             method=request.method,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
     - Serializers: advanced/serializers.md
     - Controllers: advanced/controllers.md
     - HTTP Headers: advanced/http_headers.md
+    - Extensions: advanced/extensions.md
   - Examples:
     - FastAPI: examples/fastapi.md
     - Flask: examples/flask.md

--- a/tests/_async/test_pool.py
+++ b/tests/_async/test_pool.py
@@ -3,7 +3,7 @@ import pytest
 from httpcore._models import Request, Response
 
 import hishel
-from hishel._utils import extract_header_values, header_presents
+from hishel._utils import BaseClock, extract_header_values, header_presents
 
 
 @pytest.mark.anyio
@@ -147,3 +147,37 @@ async def test_pool_with_only_if_cached_directive_with_stored_response(use_temp_
                 headers=[(b"Cache-Control", b"only-if-cached")],
             )
             assert response.status == 504
+
+
+@pytest.mark.anyio
+async def test_pool_with_cache_disabled_extension(use_temp_dir):
+    class MockedClock(BaseClock):
+        def now(self) -> int:
+            return 1440504001  # Mon, 25 Aug 2015 12:00:01 GMT
+
+    cachable_response = httpcore.Response(
+        200,
+        headers=[
+            (b"Cache-Control", b"max-age=3600"),
+            (b"Date", b"Mon, 25 Aug 2015 12:00:00 GMT"),  # 1 second before the clock
+        ],
+    )
+
+    async with hishel.MockAsyncConnectionPool() as pool:
+        pool.add_responses([cachable_response, httpcore.Response(201)])
+        async with hishel.AsyncCacheConnectionPool(
+            pool=pool, controller=hishel.Controller(clock=MockedClock())
+        ) as cache_transport:
+            request = httpcore.Request("GET", "https://www.example.com")
+            # This should create a cache entry
+            await cache_transport.handle_async_request(request)
+            # This should return from cache
+            response = await cache_transport.handle_async_request(request)
+            assert response.extensions["from_cache"]
+            # This should ignore the cache
+            caching_disabled_request = httpcore.Request(
+                "GET", "https://www.example.com", extensions={"cache_disabled": True}
+            )
+            response = await cache_transport.handle_async_request(caching_disabled_request)
+            assert not response.extensions["from_cache"]
+            assert response.status == 201

--- a/tests/_async/test_transport.py
+++ b/tests/_async/test_transport.py
@@ -2,6 +2,7 @@ import httpx
 import pytest
 
 import hishel
+from hishel._utils import BaseClock
 
 
 @pytest.mark.anyio
@@ -165,3 +166,37 @@ async def test_transport_with_only_if_cached_directive_with_stored_response(
                 )
             )
             assert response.status_code == 504
+
+
+@pytest.mark.anyio
+async def test_transport_with_cache_disabled_extension(use_temp_dir):
+    class MockedClock(BaseClock):
+        def now(self) -> int:
+            return 1440504001  # Mon, 25 Aug 2015 12:00:01 GMT
+
+    cachable_response = httpx.Response(
+        200,
+        headers=[
+            (b"Cache-Control", b"max-age=3600"),
+            (b"Date", b"Mon, 25 Aug 2015 12:00:00 GMT"),  # 1 second before the clock
+        ],
+    )
+
+    async with hishel.MockAsyncTransport() as transport:
+        transport.add_responses([cachable_response, httpx.Response(201)])
+        async with hishel.AsyncCacheTransport(
+            transport=transport, controller=hishel.Controller(clock=MockedClock())
+        ) as cache_transport:
+            request = httpx.Request("GET", "https://www.example.com")
+            # This should create a cache entry
+            await cache_transport.handle_async_request(request)
+            # This should return from cache
+            response = await cache_transport.handle_async_request(request)
+            assert response.extensions["from_cache"]
+            # This should ignore the cache
+            caching_disabled_request = httpx.Request(
+                "GET", "https://www.example.com", extensions={"cache_disabled": True}
+            )
+            response = await cache_transport.handle_async_request(caching_disabled_request)
+            assert not response.extensions["from_cache"]
+            assert response.status_code == 201

--- a/tests/_sync/test_pool.py
+++ b/tests/_sync/test_pool.py
@@ -3,7 +3,7 @@ import pytest
 from httpcore._models import Request, Response
 
 import hishel
-from hishel._utils import extract_header_values, header_presents
+from hishel._utils import BaseClock, extract_header_values, header_presents
 
 
 
@@ -147,3 +147,37 @@ def test_pool_with_only_if_cached_directive_with_stored_response(use_temp_dir):
                 headers=[(b"Cache-Control", b"only-if-cached")],
             )
             assert response.status == 504
+
+
+
+def test_pool_with_cache_disabled_extension(use_temp_dir):
+    class MockedClock(BaseClock):
+        def now(self) -> int:
+            return 1440504001  # Mon, 25 Aug 2015 12:00:01 GMT
+
+    cachable_response = httpcore.Response(
+        200,
+        headers=[
+            (b"Cache-Control", b"max-age=3600"),
+            (b"Date", b"Mon, 25 Aug 2015 12:00:00 GMT"),  # 1 second before the clock
+        ],
+    )
+
+    with hishel.MockConnectionPool() as pool:
+        pool.add_responses([cachable_response, httpcore.Response(201)])
+        with hishel.CacheConnectionPool(
+            pool=pool, controller=hishel.Controller(clock=MockedClock())
+        ) as cache_transport:
+            request = httpcore.Request("GET", "https://www.example.com")
+            # This should create a cache entry
+            cache_transport.handle_request(request)
+            # This should return from cache
+            response = cache_transport.handle_request(request)
+            assert response.extensions["from_cache"]
+            # This should ignore the cache
+            caching_disabled_request = httpcore.Request(
+                "GET", "https://www.example.com", extensions={"cache_disabled": True}
+            )
+            response = cache_transport.handle_request(caching_disabled_request)
+            assert not response.extensions["from_cache"]
+            assert response.status == 201

--- a/tests/_sync/test_transport.py
+++ b/tests/_sync/test_transport.py
@@ -2,6 +2,7 @@ import httpx
 import pytest
 
 import hishel
+from hishel._utils import BaseClock
 
 
 
@@ -165,3 +166,37 @@ def test_transport_with_only_if_cached_directive_with_stored_response(
                 )
             )
             assert response.status_code == 504
+
+
+
+def test_transport_with_cache_disabled_extension(use_temp_dir):
+    class MockedClock(BaseClock):
+        def now(self) -> int:
+            return 1440504001  # Mon, 25 Aug 2015 12:00:01 GMT
+
+    cachable_response = httpx.Response(
+        200,
+        headers=[
+            (b"Cache-Control", b"max-age=3600"),
+            (b"Date", b"Mon, 25 Aug 2015 12:00:00 GMT"),  # 1 second before the clock
+        ],
+    )
+
+    with hishel.MockTransport() as transport:
+        transport.add_responses([cachable_response, httpx.Response(201)])
+        with hishel.CacheTransport(
+            transport=transport, controller=hishel.Controller(clock=MockedClock())
+        ) as cache_transport:
+            request = httpx.Request("GET", "https://www.example.com")
+            # This should create a cache entry
+            cache_transport.handle_request(request)
+            # This should return from cache
+            response = cache_transport.handle_request(request)
+            assert response.extensions["from_cache"]
+            # This should ignore the cache
+            caching_disabled_request = httpx.Request(
+                "GET", "https://www.example.com", extensions={"cache_disabled": True}
+            )
+            response = cache_transport.handle_request(caching_disabled_request)
+            assert not response.extensions["from_cache"]
+            assert response.status_code == 201


### PR DESCRIPTION
Continuation of #105. My Git-Fu is not strong enough to fix the revision history, so I opened a new PR with a clean revision history. This implements the `{"cache_disabled": True}` extension on the sync and async transports, and adds documentation on the feature.