### PR TITLE
Version 0.0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.0.18 (23/11/2023)
 
 - Fix issue where freshness cannot be calculated to re-send request. (#104)
 - Add `cache_disabled` extension to temporarily disable the cache (#109)

--- a/hishel/__init__.py
+++ b/hishel/__init__.py
@@ -13,4 +13,4 @@ def install_cache() -> None:  # pragma: no cover
     httpx.Client = CacheClient  # type: ignore
 
 
-__version__ = "0.0.17"
+__version__ = "0.0.18"

--- a/hishel/_sync/_pool.py
+++ b/hishel/_sync/_pool.py
@@ -119,7 +119,9 @@ class CacheConnectionPool(RequestInterface):
 
         if self._controller.is_cachable(request=request, response=response):
             response.read()
-            metadata = Metadata(cache_key=key, created_at=datetime.datetime.now(datetime.timezone.utc), number_of_uses=0)
+            metadata = Metadata(
+                cache_key=key, created_at=datetime.datetime.now(datetime.timezone.utc), number_of_uses=0
+            )
             self._storage.store(key, response=response, request=request, metadata=metadata)
 
         response.extensions["from_cache"] = False  # type: ignore[index]

--- a/hishel/_sync/_transports.py
+++ b/hishel/_sync/_transports.py
@@ -210,7 +210,9 @@ class CacheTransport(httpx.BaseTransport):
         httpcore_response.close()
 
         if self._controller.is_cachable(request=httpcore_request, response=httpcore_response):
-            metadata = Metadata(cache_key=key, created_at=datetime.datetime.now(datetime.timezone.utc), number_of_uses=0)
+            metadata = Metadata(
+                cache_key=key, created_at=datetime.datetime.now(datetime.timezone.utc), number_of_uses=0
+            )
             self._storage.store(
                 key,
                 response=httpcore_response,

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,8 @@ mkdocstrings[python]==0.23.0
 pytest==7.4.3
 pytest-asyncio==0.21.1
 types-redis==4.6.0.7
-trio==0.22.2
+anyio==4.1.0
+trio==0.23.1
 coverage==7.3.2
 types-PyYAML==6.0.12.12
 typing_extensions==4.8.0

--- a/scripts/check
+++ b/scripts/check
@@ -3,4 +3,4 @@
 ruff format tests hishel --diff
 ruff tests hishel
 mypy tests hishel
-python unasync.py check
+python unasync.py --check


### PR DESCRIPTION
# Changelog

## 0.0.18 (23/11/2023)

- Fix issue where freshness cannot be calculated to re-send request. (#104)
- Add `cache_disabled` extension to temporarily disable the cache (#109)
- Update `datetime.datetime.utcnow()` to `datetime.datetime.now(datetime.timezone.utc)` since `datetime.datetime.utcnow()` has been deprecated. (#111)

