### PR TITLE
Fix ttl for the SQLiteStorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Add `force_cache` extension to enforce the request to be cached, ignoring the HTTP headers. (#117)
-- Fix issue where sqlite storage cache get deleted immediately. (#118)
+- Fix issue where sqlite storage cache get deleted immediately. (#119)
 
 ## 0.0.18 (23/11/2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,7 @@
 ## Unreleased
 
 - Add `force_cache` extension to enforce the request to be cached, ignoring the HTTP headers. (#117)
-
-## 0.0.19 (29/11/2023)
 - Fix issue where sqlite storage cache get deleted immediately. (#118)
-- Update `DELETE FROM cache WHERE datetime(date_created, '+{self._ttl} seconds') > datetime()` to `DELETE FROM cache WHERE datetime(date_created, '+{self._ttl} seconds') < datetime()`
-- Add test case for testing sqlite storage cache lifecycle.
 
 ## 0.0.18 (23/11/2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - Add `force_cache` extension to enforce the request to be cached, ignoring the HTTP headers. (#117)
 
+## 0.0.19 (29/11/2023)
+- Fix issue where sqlite storage cache get deleted immediately. (#118)
+- Update `DELETE FROM cache WHERE datetime(date_created, '+{self._ttl} seconds') > datetime()` to `DELETE FROM cache WHERE datetime(date_created, '+{self._ttl} seconds') < datetime()`
+- Add test case for testing sqlite storage cache lifecycle.
+
 ## 0.0.18 (23/11/2023)
 
 - Fix issue where freshness cannot be calculated to re-send request. (#104)

--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -233,7 +233,7 @@ class AsyncSQLiteStorage(AsyncBaseStorage):
 
         async with self._lock:
             await self._connection.execute(
-                f"DELETE FROM cache WHERE datetime(date_created, '+{self._ttl} seconds') > datetime()"
+                f"DELETE FROM cache WHERE datetime(date_created, '+{self._ttl} seconds') < datetime()"
             )
             await self._connection.commit()
 

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -233,7 +233,7 @@ class SQLiteStorage(BaseStorage):
 
         with self._lock:
             self._connection.execute(
-                f"DELETE FROM cache WHERE datetime(date_created, '+{self._ttl} seconds') > datetime()"
+                f"DELETE FROM cache WHERE datetime(date_created, '+{self._ttl} seconds') < datetime()"
             )
             self._connection.commit()
 

--- a/tests/_async/test_storages.py
+++ b/tests/_async/test_storages.py
@@ -105,6 +105,7 @@ async def test_filestorage_expired():
     await response.aread()
 
     await storage.store(first_key, response=response, request=first_request, metadata=dummy_metadata)
+    assert await storage.retreive(first_key) is not None
 
     await asleep(2)
     await storage.store(second_key, response=response, request=second_request, metadata=dummy_metadata)
@@ -127,6 +128,7 @@ async def test_redisstorage_expired():
     await response.aread()
 
     await storage.store(first_key, response=response, request=first_request, metadata=dummy_metadata)
+    assert await storage.retreive(first_key) is not None
 
     await asleep(2)
     await storage.store(second_key, response=response, request=second_request, metadata=dummy_metadata)
@@ -147,36 +149,9 @@ async def test_sqlite_expired():
     await response.aread()
 
     await storage.store(first_key, response=response, request=first_request, metadata=dummy_metadata)
+    assert await storage.retreive(first_key) is not None
 
     await asleep(2)
     await storage.store(second_key, response=response, request=second_request, metadata=dummy_metadata)
 
     assert await storage.retreive(first_key) is None
-
-
-@pytest.mark.asyncio
-async def test_sqlite_cache_lifecycle():
-    storage = AsyncSQLiteStorage(ttl=5, connection=await anysqlite.connect(":memory:"))
-    req = Request(b"GET", "https://example.com")
-
-    key = generate_key(req)
-
-    response = Response(200, headers=[], content=b"test")
-    await response.aread()
-
-    await storage.store(key, response=response, request=req, metadata=dummy_metadata)
-
-    await asleep(2)
-
-    stored_data = await storage.retreive(key)
-    assert stored_data is not None
-    stored_response, stored_request, metadata = stored_data
-    stored_response.read()
-    assert isinstance(stored_response, Response)
-    assert stored_response.status == 200
-    assert stored_response.headers == []
-    assert stored_response.content == b"test"
-
-    await asleep(4)
-
-    assert await storage.retreive(key) is None

--- a/tests/_async/test_storages.py
+++ b/tests/_async/test_storages.py
@@ -154,7 +154,6 @@ async def test_sqlite_expired():
     assert await storage.retreive(first_key) is None
 
 
-
 @pytest.mark.asyncio
 async def test_sqlite_cache_lifecycle():
     storage = AsyncSQLiteStorage(ttl=5, connection=await anysqlite.connect(":memory:"))

--- a/tests/_sync/test_storages.py
+++ b/tests/_sync/test_storages.py
@@ -105,6 +105,7 @@ def test_filestorage_expired():
     response.read()
 
     storage.store(first_key, response=response, request=first_request, metadata=dummy_metadata)
+    assert storage.retreive(first_key) is not None
 
     sleep(2)
     storage.store(second_key, response=response, request=second_request, metadata=dummy_metadata)
@@ -127,6 +128,7 @@ def test_redisstorage_expired():
     response.read()
 
     storage.store(first_key, response=response, request=first_request, metadata=dummy_metadata)
+    assert storage.retreive(first_key) is not None
 
     sleep(2)
     storage.store(second_key, response=response, request=second_request, metadata=dummy_metadata)
@@ -147,36 +149,9 @@ def test_sqlite_expired():
     response.read()
 
     storage.store(first_key, response=response, request=first_request, metadata=dummy_metadata)
+    assert storage.retreive(first_key) is not None
 
     sleep(2)
     storage.store(second_key, response=response, request=second_request, metadata=dummy_metadata)
 
     assert storage.retreive(first_key) is None
-
-
-
-def test_sqlite_cache_lifecycle():
-    storage = SQLiteStorage(ttl=5, connection=sqlite3.connect(":memory:"))
-    req = Request(b"GET", "https://example.com")
-
-    key = generate_key(req)
-
-    response = Response(200, headers=[], content=b"test")
-    response.read()
-
-    storage.store(key, response=response, request=req, metadata=dummy_metadata)
-
-    sleep(2)
-
-    stored_data = storage.retreive(key)
-    assert stored_data is not None
-    stored_response, stored_request, metadata = stored_data
-    stored_response.read()
-    assert isinstance(stored_response, Response)
-    assert stored_response.status == 200
-    assert stored_response.headers == []
-    assert stored_response.content == b"test"
-
-    sleep(4)
-
-    assert storage.retreive(key) is None

--- a/tests/_sync/test_storages.py
+++ b/tests/_sync/test_storages.py
@@ -152,3 +152,31 @@ def test_sqlite_expired():
     storage.store(second_key, response=response, request=second_request, metadata=dummy_metadata)
 
     assert storage.retreive(first_key) is None
+
+
+
+def test_sqlite_cache_lifecycle():
+    storage = SQLiteStorage(ttl=5, connection=sqlite3.connect(":memory:"))
+    req = Request(b"GET", "https://example.com")
+
+    key = generate_key(req)
+
+    response = Response(200, headers=[], content=b"test")
+    response.read()
+
+    storage.store(key, response=response, request=req, metadata=dummy_metadata)
+
+    sleep(2)
+
+    stored_data = storage.retreive(key)
+    assert stored_data is not None
+    stored_response, stored_request, metadata = stored_data
+    stored_response.read()
+    assert isinstance(stored_response, Response)
+    assert stored_response.status == 200
+    assert stored_response.headers == []
+    assert stored_response.content == b"test"
+
+    sleep(4)
+
+    assert storage.retreive(key) is None


### PR DESCRIPTION
- Replace bigger than sign with smaller in sync and async in _remove_expired_caches for sqlite.
- Add two test cases for sync and async to test sqlite cache lifecycle.