### PR TITLE
Version 0.0.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.0.19 (30/11/2023)
 
 - Add `force_cache` extension to enforce the request to be cached, ignoring the HTTP headers. (#117)
 - Fix issue where sqlite storage cache get deleted immediately. (#119)

--- a/hishel/__init__.py
+++ b/hishel/__init__.py
@@ -13,4 +13,4 @@ def install_cache() -> None:  # pragma: no cover
     httpx.Client = CacheClient  # type: ignore
 
 
-__version__ = "0.0.18"
+__version__ = "0.0.19"


### PR DESCRIPTION
# Changelog

## 0.0.19 (30/11/2023)

- Add `force_cache` extension to enforce the request to be cached, ignoring the HTTP headers. (#117)
- Fix issue where sqlite storage cache get deleted immediately. (#119)
- Support float numbers for storage ttl. (#107)
