### PR TITLE
Remove black from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@
 # linting
 ruff==0.1.6
 mypy==1.5.1
-black==23.7.0
 
 # docs
 mkdocs==1.5.3


### PR DESCRIPTION
https://github.com/karpetrosyan/hishel/pull/106 switched the formatter from `ruff` to `black` but didn't removed black from the `requirements.txt`