### PR TITLE
Add in-memory storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add in-memory storage. (#133)
 - Allow customization of cache key generation. (#130)
 
 ## 0.0.19 (30/11/2023)

--- a/hishel/__init__.py
+++ b/hishel/__init__.py
@@ -6,6 +6,7 @@ from ._exceptions import *
 from ._headers import *
 from ._serializers import *
 from ._sync import *
+from ._lfu_cache import *
 
 
 def install_cache() -> None:  # pragma: no cover

--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -325,6 +325,8 @@ class AsyncInMemoryStorage(AsyncBaseStorage):
     :type serializer: tp.Optional[BaseSerializer], optional
     :param ttl: Specifies the maximum number of seconds that the response can be cached, defaults to None
     :type ttl: tp.Optional[tp.Union[int, float]], optional
+    :param capacity: The maximum number of responses that can be cached, defaults to 128
+    :type capacity: int, optional
     """
 
     def __init__(

--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -11,6 +11,7 @@ except ImportError:  # pragma: no cover
     anysqlite = None  # type: ignore
 
 from httpcore import Request, Response
+from typing_extensions import TypeAlias
 
 from hishel._serializers import BaseSerializer, clone_model
 
@@ -23,7 +24,7 @@ logger = logging.getLogger("hishel.storages")
 
 __all__ = ("AsyncFileStorage", "AsyncRedisStorage", "AsyncSQLiteStorage", "AsyncInMemoryStorage")
 
-StoredResponse: tp.TypeAlias = tp.Tuple[Response, Request, Metadata]
+StoredResponse: TypeAlias = tp.Tuple[Response, Request, Metadata]
 
 try:
     import redis.asyncio as redis

--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -1,6 +1,8 @@
 import logging
 import time
 import typing as tp
+import warnings
+from copy import deepcopy
 from pathlib import Path
 
 try:
@@ -10,7 +12,7 @@ except ImportError:  # pragma: no cover
 
 from httpcore import Request, Response
 
-from hishel._serializers import BaseSerializer
+from hishel._serializers import BaseSerializer, clone_model
 
 from .._files import AsyncFileManager
 from .._serializers import JSONSerializer, Metadata
@@ -19,7 +21,9 @@ from .._utils import float_seconds_to_int_milliseconds
 
 logger = logging.getLogger("hishel.storages")
 
-__all__ = ("AsyncFileStorage", "AsyncRedisStorage", "AsyncSQLiteStorage")
+__all__ = ("AsyncFileStorage", "AsyncRedisStorage", "AsyncSQLiteStorage", "AsyncInMemoryStorage")
+
+StoredResponse: tp.TypeAlias = tp.Tuple[Response, Request, Metadata]
 
 try:
     import redis.asyncio as redis
@@ -39,7 +43,7 @@ class AsyncBaseStorage:
     async def store(self, key: str, response: Response, request: Request, metadata: Metadata) -> None:
         raise NotImplementedError()
 
-    async def retrieve(self, key: str) -> tp.Optional[tp.Tuple[Response, Request, Metadata]]:
+    async def retrieve(self, key: str) -> tp.Optional[StoredResponse]:
         raise NotImplementedError()
 
     async def aclose(self) -> None:
@@ -96,14 +100,14 @@ class AsyncFileStorage(AsyncBaseStorage):
             )
         await self._remove_expired_caches()
 
-    async def retrieve(self, key: str) -> tp.Optional[tp.Tuple[Response, Request, Metadata]]:
+    async def retrieve(self, key: str) -> tp.Optional[StoredResponse]:
         """
         Retreives the response from the cache using his key.
 
         :param key: Hashed value of concatenated HTTP method and URI
         :type key: str
         :return: An HTTP response and his HTTP request.
-        :rtype: tp.Optional[tp.Tuple[Response, Request, Metadata]]
+        :rtype: tp.Optional[StoredResponse]
         """
 
         response_path = self._base_path / key
@@ -199,14 +203,14 @@ class AsyncSQLiteStorage(AsyncBaseStorage):
             await self._connection.commit()
         await self._remove_expired_caches()
 
-    async def retrieve(self, key: str) -> tp.Optional[tp.Tuple[Response, Request, Metadata]]:
+    async def retrieve(self, key: str) -> tp.Optional[StoredResponse]:
         """
         Retreives the response from the cache using his key.
 
         :param key: Hashed value of concatenated HTTP method and URI
         :type key: str
         :return: An HTTP response and its HTTP request.
-        :rtype: tp.Optional[tp.Tuple[Response, Request, Metadata]]
+        :rtype: tp.Optional[StoredResponse]
         """
 
         await self._setup()
@@ -292,14 +296,14 @@ class AsyncRedisStorage(AsyncBaseStorage):
             key, self._serializer.dumps(response=response, request=request, metadata=metadata), px=px
         )
 
-    async def retrieve(self, key: str) -> tp.Optional[tp.Tuple[Response, Request, Metadata]]:
+    async def retrieve(self, key: str) -> tp.Optional[StoredResponse]:
         """
         Retreives the response from the cache using his key.
 
         :param key: Hashed value of concatenated HTTP method and URI
         :type key: str
         :return: An HTTP response and its HTTP request.
-        :rtype: tp.Optional[tp.Tuple[Response, Request, Metadata]]
+        :rtype: tp.Optional[StoredResponse]
         """
 
         cached_response = await self._client.get(key)
@@ -310,3 +314,87 @@ class AsyncRedisStorage(AsyncBaseStorage):
 
     async def aclose(self) -> None:  # pragma: no cover
         await self._client.close()
+
+
+class AsyncInMemoryStorage(AsyncBaseStorage):
+    """
+    A simple in-memory storage.
+
+    :param serializer: Serializer capable of serializing and de-serializing http responses, defaults to None
+    :type serializer: tp.Optional[BaseSerializer], optional
+    :param ttl: Specifies the maximum number of seconds that the response can be cached, defaults to None
+    :type ttl: tp.Optional[tp.Union[int, float]], optional
+    """
+
+    def __init__(
+        self,
+        serializer: tp.Optional[BaseSerializer] = None,
+        ttl: tp.Optional[tp.Union[int, float]] = None,
+        capacity: int = 128,
+    ) -> None:
+        super().__init__(serializer, ttl)
+
+        if serializer is not None:  # pragma: no cover
+            warnings.warn("The serializer is not used in the in-memory storage.", RuntimeWarning)
+
+        from hishel import LFUCache
+
+        self._cache: LFUCache[str, tp.Tuple[StoredResponse, float]] = LFUCache(capacity=capacity)
+        self._lock = AsyncLock()
+
+    async def store(self, key: str, response: Response, request: Request, metadata: Metadata) -> None:
+        """
+        Stores the response in the cache.
+
+        :param key: Hashed value of concatenated HTTP method and URI
+        :type key: str
+        :param response: An HTTP response
+        :type response: httpcore.Response
+        :param request: An HTTP request
+        :type request: httpcore.Request
+        :param metadata: Additioal information about the stored response
+        :type metadata: Metadata
+        """
+
+        async with self._lock:
+            response_clone = clone_model(response)
+            request_clone = clone_model(request)
+            stored_response: StoredResponse = (deepcopy(response_clone), deepcopy(request_clone), metadata)
+            self._cache.put(key, (stored_response, time.monotonic()))
+
+    async def retrieve(self, key: str) -> tp.Optional[StoredResponse]:
+        """
+        Retreives the response from the cache using his key.
+
+        :param key: Hashed value of concatenated HTTP method and URI
+        :type key: str
+        :return: An HTTP response and its HTTP request.
+        :rtype: tp.Optional[StoredResponse]
+        """
+
+        await self._remove_expired_caches()
+        async with self._lock:
+            try:
+                stored_response, _ = self._cache.get(key)
+            except KeyError:
+                return None
+            return stored_response
+
+    async def aclose(self) -> None:  # pragma: no cover
+        return
+
+    async def _remove_expired_caches(self) -> None:
+        if self._ttl is None:
+            return
+
+        async with self._lock:
+            keys_to_remove = set()
+
+            for key in self._cache:
+                created_at = self._cache.get(key)[1]
+
+                if time.monotonic() - created_at > self._ttl:
+                    keys_to_remove.add(key)
+
+            for key in keys_to_remove:
+                self._cache.remove_key(key)

--- a/hishel/_lfu_cache.py
+++ b/hishel/_lfu_cache.py
@@ -1,0 +1,72 @@
+from collections import OrderedDict, defaultdict
+from typing import Dict, Generic, Iterator, Tuple, TypeVar
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+__all__ = ["LFUCache"]
+
+
+class LFUCache(Generic[K, V]):
+    def __init__(self, capacity: int):
+        if capacity <= 0:
+            raise ValueError("Capacity must be positive")
+
+        self.capacity = capacity
+        self.cache: Dict[K, Tuple[V, int]] = {}  # To store key-value pairs
+        self.freq_count: defaultdict[int, OrderedDict[K, V]] = defaultdict(
+            OrderedDict
+        )  # To store frequency of each key
+        self.min_freq = 0  # To keep track of the minimum frequency
+
+    def get(self, key: K) -> V:
+        if key in self.cache:
+            value, freq = self.cache[key]
+            # Update frequency and move the key to the next frequency bucket
+            self.freq_count[freq].pop(key)
+            if not self.freq_count[freq]:  # If the current frequency has no keys, update min_freq
+                del self.freq_count[freq]
+                if freq == self.min_freq:
+                    self.min_freq += 1
+            freq += 1
+            self.freq_count[freq][key] = value
+            self.cache[key] = (value, freq)
+            return value
+        raise KeyError(f"Key {key} not found")
+
+    def put(self, key: K, value: V) -> None:
+        if key in self.cache:
+            _, freq = self.cache[key]
+            # Update frequency and move the key to the next frequency bucket
+            self.freq_count[freq].pop(key)
+            if not self.freq_count[freq]:
+                del self.freq_count[freq]
+                if freq == self.min_freq:
+                    self.min_freq += 1
+            freq += 1
+            self.freq_count[freq][key] = value
+            self.cache[key] = (value, freq)
+        else:
+            # Check if cache is full, evict the least frequently used item
+            if len(self.cache) == self.capacity:
+                evicted_key, _ = self.freq_count[self.min_freq].popitem(last=False)
+                del self.cache[evicted_key]
+
+            # Add the new key-value pair with frequency 1
+            self.cache[key] = (value, 1)
+            self.freq_count[1][key] = value
+            self.min_freq = 1
+
+    def remove_key(self, key: K) -> None:
+        if key in self.cache:
+            _, freq = self.cache[key]
+            self.freq_count[freq].pop(key)
+            if not self.freq_count[freq]:  # If the current frequency has no keys, update min_freq
+                del self.freq_count[freq]
+                if freq == self.min_freq:
+                    self.min_freq += 1
+            del self.cache[key]
+
+    def __iter__(self) -> Iterator[K]:
+        for key in self.cache:
+            yield key

--- a/hishel/_lfu_cache.py
+++ b/hishel/_lfu_cache.py
@@ -1,5 +1,5 @@
-from collections import OrderedDict, defaultdict
-from typing import Dict, Generic, Iterator, Tuple, TypeVar
+from collections import OrderedDict
+from typing import DefaultDict, Dict, Generic, Iterator, Tuple, TypeVar
 
 K = TypeVar("K")
 V = TypeVar("V")
@@ -14,7 +14,7 @@ class LFUCache(Generic[K, V]):
 
         self.capacity = capacity
         self.cache: Dict[K, Tuple[V, int]] = {}  # To store key-value pairs
-        self.freq_count: defaultdict[int, OrderedDict[K, V]] = defaultdict(
+        self.freq_count: DefaultDict[int, OrderedDict[K, V]] = DefaultDict(
             OrderedDict
         )  # To store frequency of each key
         self.min_freq = 0  # To keep track of the minimum frequency

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -11,6 +11,7 @@ except ImportError:  # pragma: no cover
     sqlite3 = None  # type: ignore
 
 from httpcore import Request, Response
+from typing_extensions import TypeAlias
 
 from hishel._serializers import BaseSerializer, clone_model
 
@@ -23,7 +24,7 @@ logger = logging.getLogger("hishel.storages")
 
 __all__ = ("FileStorage", "RedisStorage", "SQLiteStorage", "InMemoryStorage")
 
-StoredResponse: tp.TypeAlias = tp.Tuple[Response, Request, Metadata]
+StoredResponse: TypeAlias = tp.Tuple[Response, Request, Metadata]
 
 try:
     import redis

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -1,6 +1,8 @@
 import logging
 import time
 import typing as tp
+import warnings
+from copy import deepcopy
 from pathlib import Path
 
 try:
@@ -10,7 +12,7 @@ except ImportError:  # pragma: no cover
 
 from httpcore import Request, Response
 
-from hishel._serializers import BaseSerializer
+from hishel._serializers import BaseSerializer, clone_model
 
 from .._files import FileManager
 from .._serializers import JSONSerializer, Metadata
@@ -19,7 +21,9 @@ from .._utils import float_seconds_to_int_milliseconds
 
 logger = logging.getLogger("hishel.storages")
 
-__all__ = ("FileStorage", "RedisStorage", "SQLiteStorage")
+__all__ = ("FileStorage", "RedisStorage", "SQLiteStorage", "InMemoryStorage")
+
+StoredResponse: tp.TypeAlias = tp.Tuple[Response, Request, Metadata]
 
 try:
     import redis
@@ -39,7 +43,7 @@ class BaseStorage:
     def store(self, key: str, response: Response, request: Request, metadata: Metadata) -> None:
         raise NotImplementedError()
 
-    def retrieve(self, key: str) -> tp.Optional[tp.Tuple[Response, Request, Metadata]]:
+    def retrieve(self, key: str) -> tp.Optional[StoredResponse]:
         raise NotImplementedError()
 
     def close(self) -> None:
@@ -96,14 +100,14 @@ class FileStorage(BaseStorage):
             )
         self._remove_expired_caches()
 
-    def retrieve(self, key: str) -> tp.Optional[tp.Tuple[Response, Request, Metadata]]:
+    def retrieve(self, key: str) -> tp.Optional[StoredResponse]:
         """
         Retreives the response from the cache using his key.
 
         :param key: Hashed value of concatenated HTTP method and URI
         :type key: str
         :return: An HTTP response and his HTTP request.
-        :rtype: tp.Optional[tp.Tuple[Response, Request, Metadata]]
+        :rtype: tp.Optional[StoredResponse]
         """
 
         response_path = self._base_path / key
@@ -199,14 +203,14 @@ class SQLiteStorage(BaseStorage):
             self._connection.commit()
         self._remove_expired_caches()
 
-    def retrieve(self, key: str) -> tp.Optional[tp.Tuple[Response, Request, Metadata]]:
+    def retrieve(self, key: str) -> tp.Optional[StoredResponse]:
         """
         Retreives the response from the cache using his key.
 
         :param key: Hashed value of concatenated HTTP method and URI
         :type key: str
         :return: An HTTP response and its HTTP request.
-        :rtype: tp.Optional[tp.Tuple[Response, Request, Metadata]]
+        :rtype: tp.Optional[StoredResponse]
         """
 
         self._setup()
@@ -292,14 +296,14 @@ class RedisStorage(BaseStorage):
             key, self._serializer.dumps(response=response, request=request, metadata=metadata), px=px
         )
 
-    def retrieve(self, key: str) -> tp.Optional[tp.Tuple[Response, Request, Metadata]]:
+    def retrieve(self, key: str) -> tp.Optional[StoredResponse]:
         """
         Retreives the response from the cache using his key.
 
         :param key: Hashed value of concatenated HTTP method and URI
         :type key: str
         :return: An HTTP response and its HTTP request.
-        :rtype: tp.Optional[tp.Tuple[Response, Request, Metadata]]
+        :rtype: tp.Optional[StoredResponse]
         """
 
         cached_response = self._client.get(key)
@@ -310,3 +314,87 @@ class RedisStorage(BaseStorage):
 
     def close(self) -> None:  # pragma: no cover
         self._client.close()
+
+
+class InMemoryStorage(BaseStorage):
+    """
+    A simple in-memory storage.
+
+    :param serializer: Serializer capable of serializing and de-serializing http responses, defaults to None
+    :type serializer: tp.Optional[BaseSerializer], optional
+    :param ttl: Specifies the maximum number of seconds that the response can be cached, defaults to None
+    :type ttl: tp.Optional[tp.Union[int, float]], optional
+    """
+
+    def __init__(
+        self,
+        serializer: tp.Optional[BaseSerializer] = None,
+        ttl: tp.Optional[tp.Union[int, float]] = None,
+        capacity: int = 128,
+    ) -> None:
+        super().__init__(serializer, ttl)
+
+        if serializer is not None:  # pragma: no cover
+            warnings.warn("The serializer is not used in the in-memory storage.", RuntimeWarning)
+
+        from hishel import LFUCache
+
+        self._cache: LFUCache[str, tp.Tuple[StoredResponse, float]] = LFUCache(capacity=capacity)
+        self._lock = Lock()
+
+    def store(self, key: str, response: Response, request: Request, metadata: Metadata) -> None:
+        """
+        Stores the response in the cache.
+
+        :param key: Hashed value of concatenated HTTP method and URI
+        :type key: str
+        :param response: An HTTP response
+        :type response: httpcore.Response
+        :param request: An HTTP request
+        :type request: httpcore.Request
+        :param metadata: Additioal information about the stored response
+        :type metadata: Metadata
+        """
+
+        with self._lock:
+            response_clone = clone_model(response)
+            request_clone = clone_model(request)
+            stored_response: StoredResponse = (deepcopy(response_clone), deepcopy(request_clone), metadata)
+            self._cache.put(key, (stored_response, time.monotonic()))
+
+    def retrieve(self, key: str) -> tp.Optional[StoredResponse]:
+        """
+        Retreives the response from the cache using his key.
+
+        :param key: Hashed value of concatenated HTTP method and URI
+        :type key: str
+        :return: An HTTP response and its HTTP request.
+        :rtype: tp.Optional[StoredResponse]
+        """
+
+        self._remove_expired_caches()
+        with self._lock:
+            try:
+                stored_response, _ = self._cache.get(key)
+            except KeyError:
+                return None
+            return stored_response
+
+    def close(self) -> None:  # pragma: no cover
+        return
+
+    def _remove_expired_caches(self) -> None:
+        if self._ttl is None:
+            return
+
+        with self._lock:
+            keys_to_remove = set()
+
+            for key in self._cache:
+                created_at = self._cache.get(key)[1]
+
+                if time.monotonic() - created_at > self._ttl:
+                    keys_to_remove.add(key)
+
+            for key in keys_to_remove:
+                self._cache.remove_key(key)

--- a/tests/test_lfu_cache.py
+++ b/tests/test_lfu_cache.py
@@ -1,0 +1,91 @@
+import pytest
+
+from hishel import LFUCache
+
+
+def test_lfu_cache():
+    cache: LFUCache[int, int] = LFUCache(2)
+
+    cache.put(1, 2)
+    a = cache.get(1)
+
+    assert a == 2
+
+
+def test_lfu_cache_delete():
+    cache: LFUCache[int, int] = LFUCache(2)
+
+    cache.put(1, 2)
+    cache.put(3, 4)
+    cache.put(5, 6)
+    cache.get(3)
+    cache.get(3)
+
+    with pytest.raises(KeyError):
+        cache.get(1)
+
+
+def test_lfu_cache_invalid_capacity():
+    with pytest.raises(ValueError, match="Capacity must be positive"):
+        LFUCache(0)
+
+
+def test_lfu_cache_delete_least_frequently():
+    cache: LFUCache[int, int] = LFUCache(2)
+
+    cache.put(1, 10)
+    cache.put(2, 10)
+
+    cache.get(1)
+    cache.put(3, 10)
+
+    with pytest.raises(KeyError):
+        cache.get(2)
+
+    cache: LFUCache[int, int] = LFUCache(2)  # type: ignore[no-redef]
+
+    cache.put(1, 10)
+    cache.put(2, 10)
+
+    cache.get(2)
+    cache.put(3, 10)
+
+    with pytest.raises(KeyError):
+        cache.get(1)
+
+
+def test_lfu_cache_remove_key():
+    cache: LFUCache[int, int] = LFUCache(2)
+
+    cache.put(1, 10)
+    cache.put(2, 10)
+
+    cache.remove_key(1)
+
+    with pytest.raises(KeyError):
+        cache.get(1)
+
+    cache.put(1, 10)
+    cache.get(1)
+
+    assert cache.min_freq == 1
+    cache.remove_key(2)
+    assert cache.min_freq == 2
+
+
+def test_lfu_cache_put_existing():
+    cache: LFUCache[int, int] = LFUCache(2)
+
+    cache.put(1, 10)
+    cache.put(2, 10)
+
+    cache.put(1, 20)
+
+    assert cache.get(1) == 20
+
+    cache: LFUCache[int, int] = LFUCache(2)  # type: ignore[no-redef]
+
+    cache.put(1, 10)
+    cache.put(1, 20)
+
+    assert cache.get(1) == 20

--- a/unasync.py
+++ b/unasync.py
@@ -17,6 +17,7 @@ SUBS = [
     ("MockAsyncTransport", "MockTransport"),
     ("AsyncRedisStorage", "RedisStorage"),
     ("AsyncSQLiteStorage", "SQLiteStorage"),
+    ("AsyncInMemoryStorage", "InMemoryStorage"),
     ("import redis.asyncio as redis", "import redis"),
     ("AsyncCacheTransport", "CacheTransport"),
     ("AsyncBaseTransport", "BaseTransport"),


### PR DESCRIPTION
This pull request simply adds a new storage that stores responses in `RAM` and is not persistent.

Some applications may not require persistent storage, such as `FileSystem` storage, so this in memory storage with [LFU](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&ved=2ahUKEwiq4uqUwYmDAxXBhqQKHaYpB5QQFnoECBYQAQ&url=https%3A%2F%2Fen.wikipedia.org%2Fwiki%2FLeast_frequently_used&usg=AOvVaw28kdgF8EAc1I29PXI3EW5V&opi=89978449) caching will be useful for such applications.

Also, we may be able to replace all of the tests that previously used the filesystem with the temporary directory with in memory storage, which is much faster and less expensive.

Usage:

```python
import hishel

storage = hishel.InMemoryStorage(capacity=64)
client = hishel.CacheClient(storage=storage)

for i in range(1000):
    response = client.get("https://hishel.com")
```