### PR TITLE
Improve error message when the storage type is incorrect.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Improved error message when the storage type is incorrect. (#138)
+
 ## 0.0.20 (12/12/2023)
 
 - Add in-memory storage. (#133)

--- a/hishel/_async/_pool.py
+++ b/hishel/_async/_pool.py
@@ -39,6 +39,10 @@ class AsyncCacheConnectionPool(AsyncRequestInterface):
         controller: tp.Optional[Controller] = None,
     ) -> None:
         self._pool = pool
+
+        if not isinstance(storage, AsyncBaseStorage):
+            raise TypeError(f"Expected subclass of `AsyncBaseStorage` but got `{storage.__class__.__name__}`")
+
         self._storage = storage if storage is not None else AsyncFileStorage(serializer=JSONSerializer())
         self._controller = controller if controller is not None else Controller()
 

--- a/hishel/_async/_transports.py
+++ b/hishel/_async/_transports.py
@@ -60,6 +60,10 @@ class AsyncCacheTransport(httpx.AsyncBaseTransport):
         controller: tp.Optional[Controller] = None,
     ) -> None:
         self._transport = transport
+
+        if not isinstance(storage, AsyncBaseStorage):
+            raise TypeError(f"Expected subclass of `AsyncBaseStorage` but got `{storage.__class__.__name__}`")
+
         self._storage = storage if storage is not None else AsyncFileStorage(serializer=JSONSerializer())
         self._controller = controller if controller is not None else Controller()
 

--- a/hishel/_sync/_pool.py
+++ b/hishel/_sync/_pool.py
@@ -39,6 +39,10 @@ class CacheConnectionPool(RequestInterface):
         controller: tp.Optional[Controller] = None,
     ) -> None:
         self._pool = pool
+
+        if not isinstance(storage, BaseStorage):
+            raise TypeError(f"Expected subclass of `BaseStorage` but got `{storage.__class__.__name__}`")
+
         self._storage = storage if storage is not None else FileStorage(serializer=JSONSerializer())
         self._controller = controller if controller is not None else Controller()
 

--- a/hishel/_sync/_transports.py
+++ b/hishel/_sync/_transports.py
@@ -60,6 +60,10 @@ class CacheTransport(httpx.BaseTransport):
         controller: tp.Optional[Controller] = None,
     ) -> None:
         self._transport = transport
+
+        if not isinstance(storage, BaseStorage):
+            raise TypeError(f"Expected subclass of `BaseStorage` but got `{storage.__class__.__name__}`")
+
         self._storage = storage if storage is not None else FileStorage(serializer=JSONSerializer())
         self._controller = controller if controller is not None else Controller()
 

--- a/tests/_async/test_pool.py
+++ b/tests/_async/test_pool.py
@@ -1,5 +1,8 @@
+import typing as tp
+
 import httpcore
 import pytest
+import sniffio
 from httpcore._models import Request, Response
 
 import hishel
@@ -192,7 +195,7 @@ async def test_pool_with_cache_disabled_extension():
 
 
 @pytest.mark.anyio
-async def test_transport_with_custom_key_generator():
+async def test_pool_with_custom_key_generator():
     controller = hishel.Controller(key_generator=lambda request: request.url.host.decode())
 
     async with hishel.MockAsyncConnectionPool() as pool:
@@ -207,3 +210,23 @@ async def test_transport_with_custom_key_generator():
             response = await cache_transport.handle_async_request(request)
             assert response.extensions["from_cache"]
             assert response.extensions["cache_metadata"]["cache_key"] == "www.example.com"
+
+
+@pytest.mark.anyio
+async def test_pool_with_wrong_type_of_storage():
+    storage: tp.Union[hishel.FileStorage, hishel.AsyncFileStorage]
+
+    try:  # pragma: no cover
+        sniffio.current_async_library()
+        error = "Expected subclass of `Async" "BaseStorage` but got `FileStorage`"
+        storage = hishel.FileStorage()
+    except sniffio.AsyncLibraryNotFoundError:  # pragma: no cover
+        error = "Expected subclass of `BaseStorage` but got `Async" "FileStorage`"
+        storage = getattr(hishel, "Async" + "FileStorage")()
+
+    with pytest.raises(TypeError, match=error):
+        hishel.AsyncCacheConnectionPool(
+            pool=hishel.MockAsyncConnectionPool(),
+            controller=hishel.Controller(),
+            storage=storage,  # type: ignore
+        )

--- a/tests/_async/test_transport.py
+++ b/tests/_async/test_transport.py
@@ -1,5 +1,8 @@
+import typing as tp
+
 import httpx
 import pytest
+import sniffio
 
 import hishel
 from hishel._utils import BaseClock
@@ -230,3 +233,23 @@ async def test_transport_with_custom_key_generator():
             response = await cache_transport.handle_async_request(request)
             assert response.extensions["from_cache"]
             assert response.extensions["cache_metadata"]["cache_key"] == "www.example.com"
+
+
+@pytest.mark.anyio
+async def test_transport_with_wrong_type_of_storage():
+    storage: tp.Union[hishel.AsyncFileStorage, hishel.FileStorage]
+
+    try:  # pragma: no cover
+        sniffio.current_async_library()
+        error = "Expected subclass of `Async" "BaseStorage` but got `FileStorage`"
+        storage = hishel.FileStorage()
+    except sniffio.AsyncLibraryNotFoundError:  # pragma: no cover
+        error = "Expected subclass of `BaseStorage` but got `Async" "FileStorage`"
+        storage = getattr(hishel, "Async" + "FileStorage")()
+
+    with pytest.raises(TypeError, match=error):
+        hishel.AsyncCacheTransport(
+            transport=hishel.MockAsyncTransport(),
+            controller=hishel.Controller(),
+            storage=storage,  # type: ignore
+        )

--- a/tests/_sync/test_transport.py
+++ b/tests/_sync/test_transport.py
@@ -1,5 +1,8 @@
+import typing as tp
+
 import httpx
 import pytest
+import sniffio
 
 import hishel
 from hishel._utils import BaseClock
@@ -230,3 +233,23 @@ def test_transport_with_custom_key_generator():
             response = cache_transport.handle_request(request)
             assert response.extensions["from_cache"]
             assert response.extensions["cache_metadata"]["cache_key"] == "www.example.com"
+
+
+
+def test_transport_with_wrong_type_of_storage():
+    storage: tp.Union[hishel.FileStorage, hishel.FileStorage]
+
+    try:  # pragma: no cover
+        sniffio.current_async_library()
+        error = "Expected subclass of `Async" "BaseStorage` but got `FileStorage`"
+        storage = hishel.FileStorage()
+    except sniffio.AsyncLibraryNotFoundError:  # pragma: no cover
+        error = "Expected subclass of `BaseStorage` but got `Async" "FileStorage`"
+        storage = getattr(hishel, "Async" + "FileStorage")()
+
+    with pytest.raises(TypeError, match=error):
+        hishel.CacheTransport(
+            transport=hishel.MockTransport(),
+            controller=hishel.Controller(),
+            storage=storage,  # type: ignore
+        )


### PR DESCRIPTION
It is very common to pass synchronous storage to an asynchronous client or asynchronous storage to a synchronous client, so this pull request adds a more user-friendly error message for such cases. 

For example this is wrong:

```python
import hishel

storage = hishel.FileStorage()  # synchronous storage  (use hishel.AsyncFileStorage instead)
client = hishel.AsyncCacheClient(storage=storage)  # Async client with the sync storage
```

Related issues: #137, #70