### PR TITLE
Fix inner transport not closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix inner transport and connection pool instances closing. (#147)
 - Improved error message when the storage type is incorrect. (#138)
 
 ## 0.0.20 (12/12/2023)

--- a/hishel/_async/_pool.py
+++ b/hishel/_async/_pool.py
@@ -135,6 +135,9 @@ class AsyncCacheConnectionPool(AsyncRequestInterface):
     async def aclose(self) -> None:
         await self._storage.aclose()
 
+        if hasattr(self._pool, "aclose"):  # pragma: no cover
+            await self._pool.aclose()
+
     async def __aenter__(self: T) -> T:
         return self
 

--- a/hishel/_async/_transports.py
+++ b/hishel/_async/_transports.py
@@ -235,6 +235,7 @@ class AsyncCacheTransport(httpx.AsyncBaseTransport):
 
     async def aclose(self) -> None:
         await self._storage.aclose()
+        await self._transport.aclose()
 
     async def __aenter__(self) -> "Self":
         return self

--- a/hishel/_sync/_pool.py
+++ b/hishel/_sync/_pool.py
@@ -135,6 +135,9 @@ class CacheConnectionPool(RequestInterface):
     def close(self) -> None:
         self._storage.close()
 
+        if hasattr(self._pool, "close"):  # pragma: no cover
+            self._pool.close()
+
     def __enter__(self: T) -> T:
         return self
 

--- a/hishel/_sync/_transports.py
+++ b/hishel/_sync/_transports.py
@@ -235,6 +235,7 @@ class CacheTransport(httpx.BaseTransport):
 
     def close(self) -> None:
         self._storage.close()
+        self._transport.close()
 
     def __enter__(self) -> "Self":
         return self


### PR DESCRIPTION
The inner transport will be closed automatically when closing outer transport.
But, `CacheConnectionPool` wraps the pool of type `RequestInterface`, which do not have `close` method. I'm not sure how to fix the closing of pool.

fix #145 