### PR TITLE
Make `FileStorage` to check staleness of all cache files with set interval.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Make `FileStorage` to check staleness of all cache files with set interval. (#169)
 - Support AWS S3 storages. (#164)
 - Move `typing_extensions` from requirements.txt to pyproject.toml. (#161)
 

--- a/docs/advanced/storages.md
+++ b/docs/advanced/storages.md
@@ -71,6 +71,18 @@ storage = hishel.FileStorage(ttl=3600)
 If you do this, `Hishel` will delete any stored responses whose ttl has expired.
 In this example, the stored responses were limited to 1 hour.
 
+#### Check ttl every
+
+In order to avoid excessive memory utilization, `Hishel` must periodically clean the old responses, or responses that are not being used and should be deleted from the cache.
+It clears the cache by default every minute, but you may change the interval directly with the `check_ttl_every` argument.
+
+Example:
+
+```python
+import hishel
+
+storage = hishel.FileStorage(check_ttl_every=600) # check every 600s (10m) 
+```
 
 ### :material-memory: In-memory storage
 

--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -138,7 +138,7 @@ class AsyncFileStorage(AsyncBaseStorage):
         if self._ttl is None:
             return
 
-        if self._ttl is not None and time.time() - self._timer < self._check_ttl_every:
+        if time.time() - self._timer < self._check_ttl_every:
             if response_path.is_file():
                 age = time.time() - response_path.stat().st_mtime
                 if age > self._ttl:

--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -89,7 +89,7 @@ class AsyncFileStorage(AsyncBaseStorage):
         self._file_manager = AsyncFileManager(is_binary=self._serializer.is_binary)
         self._lock = AsyncLock()
         self._check_ttl_every = check_ttl_every
-        self._timer = time.time()
+        self._last_cleaned = time.monotonic()
 
     async def store(self, key: str, response: Response, request: Request, metadata: Metadata) -> None:
         """
@@ -138,14 +138,14 @@ class AsyncFileStorage(AsyncBaseStorage):
         if self._ttl is None:
             return
 
-        if time.time() - self._timer < self._check_ttl_every:
+        if time.monotonic() - self._last_cleaned < self._check_ttl_every:
             if response_path.is_file():
                 age = time.time() - response_path.stat().st_mtime
                 if age > self._ttl:
                     response_path.unlink()
             return
 
-        self._timer = time.time()
+        self._last_cleaned = time.monotonic()
         async with self._lock:
             for file in self._base_path.iterdir():
                 if file.is_file():

--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -67,6 +67,9 @@ class AsyncFileStorage(AsyncBaseStorage):
     :type base_path: tp.Optional[Path], optional
     :param ttl: Specifies the maximum number of seconds that the response can be cached, defaults to None
     :type ttl: tp.Optional[tp.Union[int, float]], optional
+    :param check_ttl_every: How often in seconds to check staleness of **all** cache files.
+        Makes sense only with set `ttl`, defaults to 60
+    :type check_ttl_every: tp.Union[int, float]
     """
 
     def __init__(
@@ -74,6 +77,7 @@ class AsyncFileStorage(AsyncBaseStorage):
         serializer: tp.Optional[BaseSerializer] = None,
         base_path: tp.Optional[Path] = None,
         ttl: tp.Optional[tp.Union[int, float]] = None,
+        check_ttl_every: tp.Union[int, float] = 60,
     ) -> None:
         super().__init__(serializer, ttl)
 
@@ -84,6 +88,8 @@ class AsyncFileStorage(AsyncBaseStorage):
 
         self._file_manager = AsyncFileManager(is_binary=self._serializer.is_binary)
         self._lock = AsyncLock()
+        self._check_ttl_every = check_ttl_every
+        self._timer = time.time()
 
     async def store(self, key: str, response: Response, request: Request, metadata: Metadata) -> None:
         """
@@ -129,9 +135,10 @@ class AsyncFileStorage(AsyncBaseStorage):
         return
 
     async def _remove_expired_caches(self) -> None:
-        if self._ttl is None:
+        if self._ttl is None or time.time() - self._timer < self._check_ttl_every:
             return
 
+        self._timer = time.time()
         async with self._lock:
             for file in self._base_path.iterdir():
                 if file.is_file():

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -111,7 +111,7 @@ class FileStorage(BaseStorage):
                 str(response_path),
                 self._serializer.dumps(response=response, request=request, metadata=metadata),
             )
-        self._remove_expired_caches()
+        self._remove_expired_caches(response_path)
 
     def retrieve(self, key: str) -> tp.Optional[StoredResponse]:
         """
@@ -125,7 +125,7 @@ class FileStorage(BaseStorage):
 
         response_path = self._base_path / key
 
-        self._remove_expired_caches()
+        self._remove_expired_caches(response_path)
         with self._lock:
             if response_path.exists():
                 return self._serializer.loads(self._file_manager.read_from(str(response_path)))
@@ -134,8 +134,15 @@ class FileStorage(BaseStorage):
     def close(self) -> None:  # pragma: no cover
         return
 
-    def _remove_expired_caches(self) -> None:
-        if self._ttl is None or time.time() - self._timer < self._check_ttl_every:
+    def _remove_expired_caches(self, response_path: Path) -> None:
+        if self._ttl is None:
+            return
+
+        if self._ttl is not None and time.time() - self._timer < self._check_ttl_every:
+            if response_path.is_file():
+                age = time.time() - response_path.stat().st_mtime
+                if age > self._ttl:
+                    response_path.unlink()
             return
 
         self._timer = time.time()

--- a/tests/_async/test_storages.py
+++ b/tests/_async/test_storages.py
@@ -117,7 +117,7 @@ async def test_inmemorystorage():
 
 @pytest.mark.asyncio
 async def test_filestorage_expired(use_temp_dir):
-    storage = AsyncFileStorage(ttl=0.1)
+    storage = AsyncFileStorage(ttl=0.2, check_ttl_every=0.1)
     first_request = Request(b"GET", "https://example.com")
     second_request = Request(b"GET", "https://anotherexample.com")
 
@@ -133,6 +133,23 @@ async def test_filestorage_expired(use_temp_dir):
     await asleep(0.3)
     await storage.store(second_key, response=response, request=second_request, metadata=dummy_metadata)
 
+    assert await storage.retrieve(first_key) is None
+
+
+@pytest.mark.asyncio
+async def test_filestorage_timer(use_temp_dir):
+    storage = AsyncFileStorage(ttl=0.1, check_ttl_every=0.3)
+
+    request = Request(b"GET", "https://example.com")
+    first_key = generate_key(request)
+    response = Response(200, headers=[], content=b"test")
+    await response.aread()
+
+    await storage.store(first_key, response=response, request=request, metadata=dummy_metadata)
+    assert await storage.retrieve(first_key) is not None
+    await asleep(0.2)
+    assert await storage.retrieve(first_key) is not None
+    await asleep(0.1)
     assert await storage.retrieve(first_key) is None
 
 

--- a/tests/_sync/test_storages.py
+++ b/tests/_sync/test_storages.py
@@ -117,7 +117,7 @@ def test_inmemorystorage():
 
 
 def test_filestorage_expired(use_temp_dir):
-    storage = FileStorage(ttl=0.1)
+    storage = FileStorage(ttl=0.2, check_ttl_every=0.1)
     first_request = Request(b"GET", "https://example.com")
     second_request = Request(b"GET", "https://anotherexample.com")
 
@@ -133,6 +133,23 @@ def test_filestorage_expired(use_temp_dir):
     sleep(0.3)
     storage.store(second_key, response=response, request=second_request, metadata=dummy_metadata)
 
+    assert storage.retrieve(first_key) is None
+
+
+
+def test_filestorage_timer(use_temp_dir):
+    storage = FileStorage(ttl=0.1, check_ttl_every=0.3)
+
+    request = Request(b"GET", "https://example.com")
+    first_key = generate_key(request)
+    response = Response(200, headers=[], content=b"test")
+    response.read()
+
+    storage.store(first_key, response=response, request=request, metadata=dummy_metadata)
+    assert storage.retrieve(first_key) is not None
+    sleep(0.2)
+    assert storage.retrieve(first_key) is not None
+    sleep(0.1)
     assert storage.retrieve(first_key) is None
 
 

--- a/tests/_sync/test_storages.py
+++ b/tests/_sync/test_storages.py
@@ -138,19 +138,28 @@ def test_filestorage_expired(use_temp_dir):
 
 
 def test_filestorage_timer(use_temp_dir):
-    storage = FileStorage(ttl=0.1, check_ttl_every=0.3)
+    storage = FileStorage(ttl=0.2, check_ttl_every=0.2)
 
-    request = Request(b"GET", "https://example.com")
-    first_key = generate_key(request)
+    first_request = Request(b"GET", "https://example.com")
+    second_request = Request(b"GET", "https://anotherexample.com")
+
+    first_key = generate_key(first_request)
+    second_key = generate_key(second_request)
+
     response = Response(200, headers=[], content=b"test")
     response.read()
 
-    storage.store(first_key, response=response, request=request, metadata=dummy_metadata)
-    assert storage.retrieve(first_key) is not None
-    sleep(0.2)
+    storage.store(first_key, response=response, request=first_request, metadata=dummy_metadata)
     assert storage.retrieve(first_key) is not None
     sleep(0.1)
+    assert storage.retrieve(first_key) is not None
+    storage.store(second_key, response=response, request=second_request, metadata=dummy_metadata)
+    assert storage.retrieve(second_key) is not None
+    sleep(0.1)
     assert storage.retrieve(first_key) is None
+    assert storage.retrieve(second_key) is not None
+    sleep(0.1)
+    assert storage.retrieve(second_key) is None
 
 
 


### PR DESCRIPTION
This pull request partially addresses issue #167.

* Make `_remove_expired_caches` always check if current file is stale.
* Make `_remove_expired_caches` check if other files in `.cache/hishel` are stale only after a set amount of time in seconds.
* Allow user to set custom amount of time after which cache needs to be checked for stale files.