### PR TITLE
Make `FileStorage` to invalidate an empty file instead of trying to parse it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix an issue where an empty file in `FileCache` could cause a parsing error. (#181)
+
 ## 0.0.22 (31th January, 2024)
 
 - Make `FileStorage` to check staleness of all cache files with set interval. (#169)

--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -128,7 +128,9 @@ class AsyncFileStorage(AsyncBaseStorage):
         await self._remove_expired_caches(response_path)
         async with self._lock:
             if response_path.exists():
-                return self._serializer.loads(await self._file_manager.read_from(str(response_path)))
+                read_data = await self._file_manager.read_from(str(response_path))
+                if len(read_data) != 0:
+                    return self._serializer.loads(read_data)
         return None
 
     async def aclose(self) -> None:  # pragma: no cover

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -128,7 +128,9 @@ class FileStorage(BaseStorage):
         self._remove_expired_caches(response_path)
         with self._lock:
             if response_path.exists():
-                return self._serializer.loads(self._file_manager.read_from(str(response_path)))
+                read_data = self._file_manager.read_from(str(response_path))
+                if len(read_data) != 0:
+                    return self._serializer.loads(read_data)
         return None
 
     def close(self) -> None:  # pragma: no cover

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ trio==0.24.0
 coverage==7.4.1
 types-PyYAML==6.0.12.12
 moto[s3]==4.2.14
+pytest-httpx==0.29.0
 
 # build
 hatch==1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ trio==0.24.0
 coverage==7.4.1
 types-PyYAML==6.0.12.12
 moto[s3]==4.2.14
-respx==0.20.2
 
 # build
 hatch==1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ trio==0.24.0
 coverage==7.4.1
 types-PyYAML==6.0.12.12
 moto[s3]==4.2.14
-pytest-httpx==0.29.0
+respx==0.20.2
 
 # build
 hatch==1.7.0

--- a/tests/_async/test_client.py
+++ b/tests/_async/test_client.py
@@ -1,7 +1,38 @@
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+from time import mktime
+from wsgiref.handlers import format_date_time
+
 import httpx
 import pytest
+from httpcore import Request
+from pytest_httpx import HTTPXMock
 
 import hishel
+from hishel._utils import generate_key
+
+
+@pytest.fixture()
+async def hishel_client():
+    storage = hishel.AsyncFileStorage()
+    controller = hishel.Controller()
+    client = hishel.AsyncCacheClient(
+        storage=storage,
+        controller=controller,
+    )
+
+    async with client:
+        yield client
+
+
+@pytest.fixture()
+def clear_cache():
+    yield
+    workdir = Path(os.getcwd() + "/.cache/hishel/")
+    for file in workdir.iterdir():
+        if file.is_file():
+            os.unlink(file)
 
 
 @pytest.mark.anyio
@@ -18,3 +49,40 @@ async def test_client_301():
                 "https://www.example.com",
             )
             assert response.extensions["from_cache"]
+
+
+@pytest.mark.anyio
+async def test_empty_cachefile_handling(
+    hishel_client: hishel.AsyncCacheClient, httpx_mock: HTTPXMock, clear_cache: None
+) -> None:
+    httpx_mock.add_response(
+        status_code=200,
+        headers=[
+            ("Cache-Control", "public, max-age=86400, s-maxage=86400"),
+            ("Date", format_date_time(mktime((datetime.now() - timedelta(hours=2)).timetuple()))),
+        ],
+        text="test",
+    )
+
+    request = Request(b"GET", "https://example.com")
+    key = generate_key(request)
+    filedir = Path(os.getcwd() + "/.cache/hishel/" + key)
+
+    await hishel_client.get("https://example.com")
+    response = await hishel_client.get("https://example.com")
+
+    assert response.status_code == 200
+    assert response.text == "test"
+    assert response.extensions["from_cache"] is True
+
+    with open(filedir, "w+", encoding="utf-8") as file:
+        file.truncate(0)
+    assert os.path.getsize(filedir) == 0
+
+    response = await hishel_client.get("https://example.com")
+    assert response.status_code == 200
+    assert response.text == "test"
+    assert response.extensions["from_cache"] is False
+
+    response = await hishel_client.get("https://example.com")
+    assert response.extensions["from_cache"] is True

--- a/tests/_async/test_client.py
+++ b/tests/_async/test_client.py
@@ -29,7 +29,7 @@ async def test_client_301():
 
 
 @pytest.mark.anyio
-async def test_empty_cachefile_handling(use_temp_dir: None) -> None:
+async def test_empty_cachefile_handling(use_temp_dir):
     async with hishel.MockAsyncTransport() as transport:
         transport.add_responses(
             [

--- a/tests/_async/test_storages.py
+++ b/tests/_async/test_storages.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+from pathlib import Path
 
 import anysqlite
 import boto3
@@ -292,3 +293,26 @@ async def test_inmemory_expired():
     await storage.store(second_key, response=response, request=second_request, metadata=dummy_metadata)
 
     assert await storage.retrieve(first_key) is None
+
+
+@pytest.mark.anyio
+async def test_filestorage_empty_file_exception(use_temp_dir):
+    """When working with concurrency sometimes Hishel
+    may leave a cache file empty. In this case this should not
+    cause a `JSONDecodeError`, but treat this situation as
+    no cache file was created. Issue #180"""
+
+    storage = AsyncFileStorage()
+    request = Request(b"GET", "https://example.com")
+    key = generate_key(request)
+    response = Response(200, headers=[], content=b"test")
+    await response.aread()
+    await storage.store(key, response=response, request=request, metadata=dummy_metadata)
+    stored_data = await storage.retrieve(key)
+
+    assert stored_data is not None
+    filedir = Path(os.getcwd() + "/.cache/hishel/" + key)
+    with open(filedir, "w+", encoding="utf-8") as file:
+        file.truncate(0)
+    assert os.path.getsize(filedir) == 0
+    assert await storage.retrieve(key) is None

--- a/tests/_sync/test_client.py
+++ b/tests/_sync/test_client.py
@@ -1,7 +1,38 @@
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+from time import mktime
+from wsgiref.handlers import format_date_time
+
 import httpx
 import pytest
+from httpcore import Request
+from pytest_httpx import HTTPXMock
 
 import hishel
+from hishel._utils import generate_key
+
+
+@pytest.fixture()
+def hishel_client():
+    storage = hishel.FileStorage()
+    controller = hishel.Controller()
+    client = hishel.CacheClient(
+        storage=storage,
+        controller=controller,
+    )
+
+    with client:
+        yield client
+
+
+@pytest.fixture()
+def clear_cache():
+    yield
+    workdir = Path(os.getcwd() + "/.cache/hishel/")
+    for file in workdir.iterdir():
+        if file.is_file():
+            os.unlink(file)
 
 
 
@@ -18,3 +49,40 @@ def test_client_301():
                 "https://www.example.com",
             )
             assert response.extensions["from_cache"]
+
+
+
+def test_empty_cachefile_handling(
+    hishel_client: hishel.CacheClient, httpx_mock: HTTPXMock, clear_cache: None
+) -> None:
+    httpx_mock.add_response(
+        status_code=200,
+        headers=[
+            ("Cache-Control", "public, max-age=86400, s-maxage=86400"),
+            ("Date", format_date_time(mktime((datetime.now() - timedelta(hours=2)).timetuple()))),
+        ],
+        text="test",
+    )
+
+    request = Request(b"GET", "https://example.com")
+    key = generate_key(request)
+    filedir = Path(os.getcwd() + "/.cache/hishel/" + key)
+
+    hishel_client.get("https://example.com")
+    response = hishel_client.get("https://example.com")
+
+    assert response.status_code == 200
+    assert response.text == "test"
+    assert response.extensions["from_cache"] is True
+
+    with open(filedir, "w+", encoding="utf-8") as file:
+        file.truncate(0)
+    assert os.path.getsize(filedir) == 0
+
+    response = hishel_client.get("https://example.com")
+    assert response.status_code == 200
+    assert response.text == "test"
+    assert response.extensions["from_cache"] is False
+
+    response = hishel_client.get("https://example.com")
+    assert response.extensions["from_cache"] is True

--- a/tests/_sync/test_client.py
+++ b/tests/_sync/test_client.py
@@ -29,7 +29,7 @@ def test_client_301():
 
 
 
-def test_empty_cachefile_handling(use_temp_dir: None) -> None:
+def test_empty_cachefile_handling(use_temp_dir):
     with hishel.MockTransport() as transport:
         transport.add_responses(
             [


### PR DESCRIPTION
* Fixing an issue where an empty cache file causes a parsing error when reading from a file storage.
* Adding multiple tests to test the correct behavior.