### PR TITLE
Add support for POST and other HTTP methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix an issue where an empty file in `FileCache` could cause a parsing error. (#181)
+- Support caching for `POST` and other HTTP methods. (#183)
 
 ## 0.0.22 (31th January, 2024)
 

--- a/docs/advanced/controllers.md
+++ b/docs/advanced/controllers.md
@@ -15,7 +15,7 @@ Example:
 ```python
 import hishel
 
-controller = hishel.Controller(cacheable_methods=["GET", "PUT"])
+controller = hishel.Controller(cacheable_methods=["GET", "POST"])
 client = hishel.CacheClient(controller=controller)
 ```
 
@@ -118,8 +118,8 @@ import hishel
 import httpcore
 from hishel._utils import generate_key
 
-def custom_key_generator(request: httpcore.Request):
-    key = generate_key(request)
+def custom_key_generator(request: httpcore.Request, body: bytes):
+    key = generate_key(request, body)
     method = request.method.decode()
     host = request.url.host.decode()
     return f"{method}|{host}|{key}"

--- a/hishel/_async/_mock.py
+++ b/hishel/_async/_mock.py
@@ -13,6 +13,8 @@ __all__ = ("MockAsyncConnectionPool", "MockAsyncTransport")
 
 class MockAsyncConnectionPool(AsyncRequestInterface):
     async def handle_async_request(self, request: httpcore.Request) -> httpcore.Response:
+        assert isinstance(request.stream, tp.AsyncIterable)
+        data = b"".join([chunk async for chunk in request.stream])  # noqa: F841
         return self.mocked_responses.pop(0)
 
     def add_responses(self, responses: tp.List[httpcore.Response]) -> None:

--- a/hishel/_controller.py
+++ b/hishel/_controller.py
@@ -119,7 +119,7 @@ class Controller:
             self._cacheable_methods.append("GET")
         else:
             for method in cacheable_methods:
-                if method.upper() not in ["GET", "HEAD"]:
+                if method.upper() not in HTTP_METHODS:
                     raise RuntimeError(
                         f"Hishel does not support the HTTP method `{method}`.\n"
                         f"Please use the methods from this list: {HTTP_METHODS}"

--- a/hishel/_controller.py
+++ b/hishel/_controller.py
@@ -15,6 +15,7 @@ from ._utils import (
 )
 
 HEURISTICALLY_CACHEABLE_STATUS_CODES = (200, 203, 204, 206, 300, 301, 308, 404, 405, 410, 414, 501)
+HTTP_METHODS = ["GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"]
 
 __all__ = ("Controller", "HEURISTICALLY_CACHEABLE_STATUS_CODES")
 
@@ -110,7 +111,7 @@ class Controller:
         clock: tp.Optional[BaseClock] = None,
         allow_stale: bool = False,
         always_revalidate: bool = False,
-        key_generator: tp.Optional[tp.Callable[[Request], str]] = None,
+        key_generator: tp.Optional[tp.Callable[[Request, tp.Optional[bytes]], str]] = None,
     ):
         self._cacheable_methods = []
 
@@ -120,7 +121,8 @@ class Controller:
             for method in cacheable_methods:
                 if method.upper() not in ["GET", "HEAD"]:
                     raise RuntimeError(
-                        f"Hishel does not support the HTTP method `{method}`. Please use either `GET` or `HEAD`."
+                        f"Hishel does not support the HTTP method `{method}`.\n"
+                        f"Please use the methods from this list: {HTTP_METHODS}"
                     )
                 self._cacheable_methods.append(method.upper())
 

--- a/hishel/_sync/_mock.py
+++ b/hishel/_sync/_mock.py
@@ -13,6 +13,8 @@ __all__ = ("MockConnectionPool", "MockTransport")
 
 class MockConnectionPool(RequestInterface):
     def handle_request(self, request: httpcore.Request) -> httpcore.Response:
+        assert isinstance(request.stream, tp.Iterable)
+        data = b"".join([chunk for chunk in request.stream])  # noqa: F841
         return self.mocked_responses.pop(0)
 
     def add_responses(self, responses: tp.List[httpcore.Response]) -> None:

--- a/hishel/_sync/_pool.py
+++ b/hishel/_sync/_pool.py
@@ -17,6 +17,10 @@ T = tp.TypeVar("T")
 __all__ = ("CacheConnectionPool",)
 
 
+def fake_stream(content: bytes) -> tp.Iterable[bytes]:
+    yield content
+
+
 def generate_504() -> Response:
     return Response(status=504)
 
@@ -60,7 +64,16 @@ class CacheConnectionPool(RequestInterface):
         if request.extensions.get("cache_disabled", False):
             request.headers.extend([(b"cache-control", b"no-cache"), (b"cache-control", b"max-age=0")])
 
-        key = self._controller._key_generator(request)
+        if request.method.upper() not in [b"GET", b"HEAD"]:
+            # If the HTTP method is, for example, POST,
+            # we must also use the request data to generate the hash.
+            assert isinstance(request.stream, tp.Iterable)
+            body_for_key = b"".join([chunk for chunk in request.stream])
+            request.stream = fake_stream(body_for_key)
+        else:
+            body_for_key = b""
+
+        key = self._controller._key_generator(request, body_for_key)
         stored_data = self._storage.retrieve(key)
 
         request_cache_control = parse_cache_control(extract_header_values_decoded(request.headers, b"Cache-Control"))

--- a/hishel/_sync/_transports.py
+++ b/hishel/_sync/_transports.py
@@ -87,6 +87,14 @@ class CacheTransport(httpx.BaseTransport):
                 ]
             )
 
+        if request.method not in ["GET", "HEAD"]:
+            # If the HTTP method is, for example, POST,
+            # we must also use the request data to generate the hash.
+            body_for_key = request.read()
+            request.stream = CacheStream(fake_stream(body_for_key))
+        else:
+            body_for_key = b""
+
         httpcore_request = httpcore.Request(
             method=request.method,
             url=httpcore.URL(
@@ -99,7 +107,8 @@ class CacheTransport(httpx.BaseTransport):
             content=request.stream,
             extensions=request.extensions,
         )
-        key = self._controller._key_generator(httpcore_request)
+
+        key = self._controller._key_generator(httpcore_request, body_for_key)
         stored_data = self._storage.retrieve(key)
 
         request_cache_control = parse_cache_control(

--- a/hishel/_utils.py
+++ b/hishel/_utils.py
@@ -33,13 +33,10 @@ def normalized_url(url: tp.Union[httpcore.URL, str, bytes]) -> str:
     assert False, "Invalid type for `normalized_url`"  # pragma: no cover
 
 
-def generate_key(request: httpcore.Request) -> str:
+def generate_key(request: httpcore.Request, body: bytes = b"") -> str:
     encoded_url = normalized_url(request.url).encode("ascii")
 
-    key_parts = [
-        request.method,
-        encoded_url,
-    ]
+    key_parts = [request.method, encoded_url, body]
 
     key = blake2b(digest_size=16)
     for part in key_parts:

--- a/tests/_async/test_pool.py
+++ b/tests/_async/test_pool.py
@@ -250,6 +250,6 @@ async def test_pool_caching_post_method():
             assert response.extensions["from_cache"]
 
             # This should create a new cache entry instead of using the previous one
-            response = await cache_pool.request("POST", "https://anotherexample.com", content=b"request-1")
+            response = await cache_pool.request("POST", "https://www.example.com", content=b"request-2")
             assert response.status == 200
             assert not response.extensions["from_cache"]

--- a/tests/_async/test_pool.py
+++ b/tests/_async/test_pool.py
@@ -230,3 +230,26 @@ async def test_pool_with_wrong_type_of_storage():
             controller=hishel.Controller(),
             storage=storage,  # type: ignore
         )
+
+
+@pytest.mark.anyio
+async def test_pool_caching_post_method():
+    controller = hishel.Controller(cacheable_methods=["POST"])
+
+    async with hishel.MockAsyncConnectionPool() as pool:
+        pool.add_responses([httpcore.Response(301), httpcore.Response(200)])
+        async with hishel.AsyncCacheConnectionPool(
+            pool=pool,
+            controller=controller,
+            storage=hishel.AsyncInMemoryStorage(),
+        ) as cache_pool:
+            # This should create a cache entry
+            await cache_pool.request("POST", "https://www.example.com", content=b"request-1")
+            # This should return from cache
+            response = await cache_pool.request("POST", "https://www.example.com", content=b"request-1")
+            assert response.extensions["from_cache"]
+
+            # This should create a new cache entry instead of using the previous one
+            response = await cache_pool.request("POST", "https://anotherexample.com", content=b"request-1")
+            assert response.status == 200
+            assert not response.extensions["from_cache"]

--- a/tests/_async/test_pool.py
+++ b/tests/_async/test_pool.py
@@ -196,7 +196,7 @@ async def test_pool_with_cache_disabled_extension():
 
 @pytest.mark.anyio
 async def test_pool_with_custom_key_generator():
-    controller = hishel.Controller(key_generator=lambda request: request.url.host.decode())
+    controller = hishel.Controller(key_generator=lambda request, body: request.url.host.decode())
 
     async with hishel.MockAsyncConnectionPool() as pool:
         pool.add_responses([httpcore.Response(301)])

--- a/tests/_async/test_transport.py
+++ b/tests/_async/test_transport.py
@@ -217,7 +217,7 @@ async def test_transport_with_cache_disabled_extension():
 
 @pytest.mark.anyio
 async def test_transport_with_custom_key_generator():
-    controller = hishel.Controller(key_generator=lambda request: request.url.host.decode())
+    controller = hishel.Controller(key_generator=lambda request, body: request.url.host.decode())
 
     async with hishel.MockAsyncTransport() as transport:
         transport.add_responses([httpx.Response(301)])

--- a/tests/_async/test_transport.py
+++ b/tests/_async/test_transport.py
@@ -274,7 +274,7 @@ async def test_transport_caching_post_method():
             assert response.extensions["from_cache"]
 
             # Method and URL are the same but the body is different
-            request = httpx.Request("POST", "https://anotherexample.com", json={"request": 2})
+            request = httpx.Request("POST", "https://www.example.com", json={"request": 2})
 
             # This should create a new cache entry instead of using the previous one
             response = await cache_transport.handle_async_request(request)

--- a/tests/_sync/test_pool.py
+++ b/tests/_sync/test_pool.py
@@ -196,7 +196,7 @@ def test_pool_with_cache_disabled_extension():
 
 
 def test_pool_with_custom_key_generator():
-    controller = hishel.Controller(key_generator=lambda request: request.url.host.decode())
+    controller = hishel.Controller(key_generator=lambda request, body: request.url.host.decode())
 
     with hishel.MockConnectionPool() as pool:
         pool.add_responses([httpcore.Response(301)])

--- a/tests/_sync/test_pool.py
+++ b/tests/_sync/test_pool.py
@@ -250,6 +250,6 @@ def test_pool_caching_post_method():
             assert response.extensions["from_cache"]
 
             # This should create a new cache entry instead of using the previous one
-            response = cache_pool.request("POST", "https://anotherexample.com", content=b"request-1")
+            response = cache_pool.request("POST", "https://www.example.com", content=b"request-2")
             assert response.status == 200
             assert not response.extensions["from_cache"]

--- a/tests/_sync/test_pool.py
+++ b/tests/_sync/test_pool.py
@@ -230,3 +230,26 @@ def test_pool_with_wrong_type_of_storage():
             controller=hishel.Controller(),
             storage=storage,  # type: ignore
         )
+
+
+
+def test_pool_caching_post_method():
+    controller = hishel.Controller(cacheable_methods=["POST"])
+
+    with hishel.MockConnectionPool() as pool:
+        pool.add_responses([httpcore.Response(301), httpcore.Response(200)])
+        with hishel.CacheConnectionPool(
+            pool=pool,
+            controller=controller,
+            storage=hishel.InMemoryStorage(),
+        ) as cache_pool:
+            # This should create a cache entry
+            cache_pool.request("POST", "https://www.example.com", content=b"request-1")
+            # This should return from cache
+            response = cache_pool.request("POST", "https://www.example.com", content=b"request-1")
+            assert response.extensions["from_cache"]
+
+            # This should create a new cache entry instead of using the previous one
+            response = cache_pool.request("POST", "https://anotherexample.com", content=b"request-1")
+            assert response.status == 200
+            assert not response.extensions["from_cache"]

--- a/tests/_sync/test_transport.py
+++ b/tests/_sync/test_transport.py
@@ -274,7 +274,7 @@ def test_transport_caching_post_method():
             assert response.extensions["from_cache"]
 
             # Method and URL are the same but the body is different
-            request = httpx.Request("POST", "https://anotherexample.com", json={"request": 2})
+            request = httpx.Request("POST", "https://www.example.com", json={"request": 2})
 
             # This should create a new cache entry instead of using the previous one
             response = cache_transport.handle_request(request)

--- a/tests/_sync/test_transport.py
+++ b/tests/_sync/test_transport.py
@@ -217,7 +217,7 @@ def test_transport_with_cache_disabled_extension():
 
 
 def test_transport_with_custom_key_generator():
-    controller = hishel.Controller(key_generator=lambda request: request.url.host.decode())
+    controller = hishel.Controller(key_generator=lambda request, body: request.url.host.decode())
 
     with hishel.MockTransport() as transport:
         transport.add_responses([httpx.Response(301)])

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -47,19 +47,24 @@ def test_is_cachable_for_heuristically_cachable():
     assert controller.is_cachable(request=request, response=response)
 
 
+def test_is_cachable_for_invalid_method():
+    controller = Controller(cacheable_methods=["GET"])
+
+    request = Request(b"POST", b"https://example.com", headers=[])
+
+    response = Response(200, headers=[])
+
+    assert not controller.is_cachable(request=request, response=response)
+
+
 def test_is_cachable_for_post():
-    class MockedClock(BaseClock):
-        def now(self) -> int:
-            return 1440504000
+    controller = Controller(cacheable_methods=["POST"])
 
-    controller = Controller(clock=MockedClock())
-
-    request = Request(b"GET", b"https://example.com", headers=[])
+    request = Request(b"POST", b"https://example.com", headers=[])
     response = Response(
         status=200,
         headers=[
             (b"Cache-Control", b"max-age=3600"),
-            (b"Date", b"Mon, 25 Aug 2015 12:00:00 GMT"),
         ],
     )
     assert controller.is_cachable(request=request, response=response)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 from httpcore import Request, Response
 
@@ -58,7 +60,10 @@ def test_is_cachable_for_unsupported_method():
 def test_controller_with_unsupported_method():
     with pytest.raises(
         RuntimeError,
-        match="Hishel does not support the HTTP method `DELETE`. Please use either `GET` or `HEAD`.",
+        match=re.escape(
+            "Hishel does not support the HTTP method `DELETE`.\nPlease use the methods "
+            "from this list: ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH']"
+        ),
     ):
         Controller(cacheable_methods=["DELETE"])
 


### PR DESCRIPTION
This PR adds support for caching `POST` and other `HTTP` methods.

Previously, `Hishel` supported only `GET` and `HEAD` methods, which are the only methods recommended to be cached by the [specification](https://www.rfc-editor.org/rfc/rfc9111.html#name-invalidating-stored-respons).

However, some servers use `POST` endpoints to receive structured data such as `JSON` or `XML`; these function similarly to `GET` requests and can be cached in the same way that conventional `GET` methods are.

For example, `GraphQL` APIs use the POST method to receive JSON data for filtering.

To support this feature, we must also consider how we will distinguish between two separate requests to the same URL using the same HTTP method but with different request bodies.

Now, we generate a key for each request by simply hashing the value of METHO + URL, therefore this PR includes the request body to distinguish between two separate queries to the same URL.

So we can deal with such situations appropriately.

```python
# two separate cache entries.
client.post("https://example.com/v1/cachable_post", json={"data": "request 1"}) 
client.post("https://example.com/v1/cachable_post", json={"data": "request 2"})
```

Also, you can ignore specification rules if the response doesn't support it.
Some examples:

```python
import hishel

# All the specification configs
controller = hishel.Controller(
        # Cache only GET and POST methods
        cacheable_methods=["GET", "POST"],

        # Cache only 200 status codes
        cacheable_status_codes=[200],

        # Use the stale response if there is a connection issue and the new response cannot be obtained.
        allow_stale=True,

        # First, revalidate the response and then utilize it.
        # If the response has not changed, do not download the
        # entire response data from the server; instead,
        # use the one you have because you know it has not been modified.
        always_revalidate=True,
)

# All the storage configs
storage = hishel.S3Storage(
        bucket_name="my_bucket_name", # store my cache files in the `my_bucket_name` bucket
        ttl=3600, # delete the response if it is in the cache for more than an hour
)
client = hishel.CacheClient(controller=controller, storage=storage)


# Ignore the fact that the server does not recommend you cache this request!
client.post(
        "https://example.com",
        extensions={"force_cache": True}
)


# Return a regular response if it is in the cache; else, return a 504 status code. DO NOT SEND A REQUEST!
client.post(
        "https://example.com",
        headers=[("Cache-Control", "only-if-cached")]
)


# Ignore cached responses and do not store incoming responses!
response = client.post(
        "https://example.com",
        extensions={"cache_disabled": True}
)
```
