### PR TITLE
Version 0.0.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.0.25 (23th March, 2024)
 
 - Add `force_cache` property to the controller, allowing RFC9111 rules to be completely disabled. (#204)
 - Add `.gitignore` to cache directory created by `FIleStorage`. (#197)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.0.25 (23th March, 2024)
+## 0.0.25 (26th March, 2024)
 
 - Add `force_cache` property to the controller, allowing RFC9111 rules to be completely disabled. (#204)
 - Add `.gitignore` to cache directory created by `FIleStorage`. (#197)

--- a/hishel/__init__.py
+++ b/hishel/__init__.py
@@ -14,4 +14,4 @@ def install_cache() -> None:  # pragma: no cover
     httpx.Client = CacheClient  # type: ignore
 
 
-__version__ = "0.0.24"
+__version__ = "0.0.25"


### PR DESCRIPTION
# Changelog

## 0.0.25 (26th March, 2024)

- Add `force_cache` property to the controller, allowing RFC9111 rules to be completely disabled. (#204)
- Add `.gitignore` to cache directory created by `FIleStorage`. (#197)
- Remove `stale_*` headers from the `CacheControl` class. (#199)
