### PR TITLE
Fix some sqlite backend mistakes

### DIFF
--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -190,7 +190,7 @@ class AsyncSQLiteStorage(AsyncBaseStorage):
             )
         super().__init__(serializer, ttl)
 
-        self._connection: tp.Optional[anysqlite.Connection] = connection or None
+        self._connection: tp.Optional[anysqlite.Connection] = connection if connection is not None else None
         self._setup_lock = AsyncLock()
         self._setup_completed: bool = False
         self._lock = AsyncLock()

--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -256,12 +256,11 @@ class AsyncSQLiteStorage(AsyncBaseStorage):
             return self._serializer.loads(cached_response)
 
     async def aclose(self) -> None:  # pragma: no cover
-        assert self._connection
-        await self._connection.close()
+        if self._connection is not None:
+            await self._connection.close()
 
     async def _remove_expired_caches(self) -> None:
-        assert self._connection
-        if self._ttl is None:
+        if self._ttl is None or self._connection is None:
             return
 
         async with self._lock:

--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -190,7 +190,7 @@ class AsyncSQLiteStorage(AsyncBaseStorage):
             )
         super().__init__(serializer, ttl)
 
-        self._connection: tp.Optional[anysqlite.Connection] = connection if connection is not None else None
+        self._connection: tp.Optional[anysqlite.Connection] = connection or None
         self._setup_lock = AsyncLock()
         self._setup_completed: bool = False
         self._lock = AsyncLock()

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -190,7 +190,7 @@ class SQLiteStorage(BaseStorage):
             )
         super().__init__(serializer, ttl)
 
-        self._connection: tp.Optional[sqlite3.Connection] = connection or None
+        self._connection: tp.Optional[sqlite3.Connection] = connection if connection is not None else None
         self._setup_lock = Lock()
         self._setup_completed: bool = False
         self._lock = Lock()

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -256,12 +256,11 @@ class SQLiteStorage(BaseStorage):
             return self._serializer.loads(cached_response)
 
     def close(self) -> None:  # pragma: no cover
-        assert self._connection
-        self._connection.close()
+        if self._connection is not None:
+            self._connection.close()
 
     def _remove_expired_caches(self) -> None:
-        assert self._connection
-        if self._ttl is None:
+        if self._ttl is None or self._connection is None:
             return
 
         with self._lock:

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -190,7 +190,7 @@ class SQLiteStorage(BaseStorage):
             )
         super().__init__(serializer, ttl)
 
-        self._connection: tp.Optional[sqlite3.Connection] = connection if connection is not None else None
+        self._connection: tp.Optional[sqlite3.Connection] = connection or None
         self._setup_lock = Lock()
         self._setup_completed: bool = False
         self._lock = Lock()
@@ -256,11 +256,12 @@ class SQLiteStorage(BaseStorage):
             return self._serializer.loads(cached_response)
 
     def close(self) -> None:  # pragma: no cover
-        if self._connection is not None:
-            self._connection.close()
+        assert self._connection
+        self._connection.close()
 
     def _remove_expired_caches(self) -> None:
-        if self._ttl is None or self._connection is None:
+        assert self._connection
+        if self._ttl is None:
             return
 
         with self._lock:


### PR DESCRIPTION
1. `or` converts anything to boolean, so there `self._connection` is always `True` or `False` basically
2. Since `self._connection` setup only happens if user makes request, and calls `store` or `retrieve`, there always a possibility that this code won't be called, and `self._connection` will stay null. Which will cause exception (thanks to assert) in pretty normal scenario