### PR TITLE
Add custom hasher to `generate_key` fuction

### DIFF
--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -190,7 +190,7 @@ class AsyncSQLiteStorage(AsyncBaseStorage):
             )
         super().__init__(serializer, ttl)
 
-        self._connection: tp.Optional[anysqlite.Connection] = connection or None
+        self._connection: tp.Optional[anysqlite.Connection] = connection if connection is not None else None
         self._setup_lock = AsyncLock()
         self._setup_completed: bool = False
         self._lock = AsyncLock()

--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -256,12 +256,11 @@ class AsyncSQLiteStorage(AsyncBaseStorage):
             return self._serializer.loads(cached_response)
 
     async def aclose(self) -> None:  # pragma: no cover
-        assert self._connection
-        await self._connection.close()
+        if self._connection is not None:
+            await self._connection.close()
 
     async def _remove_expired_caches(self) -> None:
-        assert self._connection
-        if self._ttl is None:
+        if self._ttl is None or self._connection is None:
             return
 
         async with self._lock:

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -190,7 +190,7 @@ class SQLiteStorage(BaseStorage):
             )
         super().__init__(serializer, ttl)
 
-        self._connection: tp.Optional[sqlite3.Connection] = connection or None
+        self._connection: tp.Optional[sqlite3.Connection] = connection if connection is not None else None
         self._setup_lock = Lock()
         self._setup_completed: bool = False
         self._lock = Lock()

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -256,12 +256,11 @@ class SQLiteStorage(BaseStorage):
             return self._serializer.loads(cached_response)
 
     def close(self) -> None:  # pragma: no cover
-        assert self._connection
-        self._connection.close()
+        if self._connection is not None:
+            self._connection.close()
 
     def _remove_expired_caches(self) -> None:
-        assert self._connection
-        if self._ttl is None:
+        if self._ttl is None or self._connection is None:
             return
 
         with self._lock:

--- a/hishel/_utils.py
+++ b/hishel/_utils.py
@@ -2,6 +2,7 @@ import calendar
 import time
 import typing as tp
 from email.utils import parsedate_tz
+from functools import partial
 from hashlib import blake2b
 
 import anyio
@@ -33,12 +34,12 @@ def normalized_url(url: tp.Union[httpcore.URL, str, bytes]) -> str:
     assert False, "Invalid type for `normalized_url`"  # pragma: no cover
 
 
-def generate_key(request: httpcore.Request, body: bytes = b"") -> str:
+def generate_key(request: httpcore.Request, body: bytes = b"", hasher = partial(blake2b, digest_size=16)) -> str:
     encoded_url = normalized_url(request.url).encode("ascii")
 
     key_parts = [request.method, encoded_url, body]
 
-    key = blake2b(digest_size=16)
+    key = hasher()
     for part in key_parts:
         key.update(part)
     return key.hexdigest()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 from httpcore import Request
+from hashlib import sha1
 
 from hishel._controller import get_updated_headers
 from hishel._utils import (
@@ -18,6 +19,12 @@ def test_generate_key():
 
     assert key == "bd152069787aaad359c85af6f2edbb25"
 
+def test_generate_key_custom_hasher():
+    request = Request(b"GET", "https://example.com", headers=[])
+
+    key = generate_key(request, hasher=sha1)
+
+    assert key == "6d748741a927b10454c83ac285b002cd239964ea"
 
 def test_extract_header_values():
     headers = [


### PR DESCRIPTION
Allows use of any hashlib-compilant hasher to use with `generate_key` in a simple fashion:
```python
def custom_key_generator(request: Request, body: bytes = b"") -> str:
    key = generate_key(request, body, xxhash.xxh3_128)
    
    method = request.method.decode()
    host = request.url.host.decode()
    return f"{method}|{host}|{key}"
```