### PR TITLE
Add hasher option to `generate_key` function

### DIFF
--- a/hishel/_utils.py
+++ b/hishel/_utils.py
@@ -1,4 +1,5 @@
 import calendar
+from functools import partial
 import time
 import typing as tp
 from email.utils import parsedate_tz
@@ -33,12 +34,12 @@ def normalized_url(url: tp.Union[httpcore.URL, str, bytes]) -> str:
     assert False, "Invalid type for `normalized_url`"  # pragma: no cover
 
 
-def generate_key(request: httpcore.Request, body: bytes = b"") -> str:
+def generate_key(request: httpcore.Request, body: bytes = b"", hasher = partial(blake2b, digest_size=16)) -> str:
     encoded_url = normalized_url(request.url).encode("ascii")
 
     key_parts = [request.method, encoded_url, body]
 
-    key = blake2b(digest_size=16)
+    key = hasher()
     for part in key_parts:
         key.update(part)
     return key.hexdigest()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+from hashlib import sha1
 from httpcore import Request
 
 from hishel._controller import get_updated_headers
@@ -18,6 +19,12 @@ def test_generate_key():
 
     assert key == "bd152069787aaad359c85af6f2edbb25"
 
+def test_generate_key_custom_hasher():
+    request = Request(b"GET", "https://example.com", headers=[])
+
+    key = generate_key(request, hasher=sha1)
+
+    assert key == "6d748741a927b10454c83ac285b002cd239964ea"
 
 def test_extract_header_values():
     headers = [


### PR DESCRIPTION
Allows use of any hashlib-compilant hasher with `generate_key` in a simple fashion:
```python
def custom_key_generator(request: Request, body: bytes = b"") -> str:
    key = generate_key(request, body, xxhash.xxh3_128)
    
    method = request.method.decode()
    host = request.url.host.decode()
    return f"{method}|{host}|{key}"
```