### PR TITLE
Tidy up ttls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unrelesed
+
+- Prevent cache hits from resetting the ttl. (#215)
+
 ## 0.0.25 (26th March, 2024)
 
 - Add `force_cache` property to the controller, allowing RFC9111 rules to be completely disabled. (#204)

--- a/hishel/_async/_pool.py
+++ b/hishel/_async/_pool.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import types
 import typing as tp
@@ -94,17 +96,9 @@ class AsyncCacheConnectionPool(AsyncRequestInterface):
 
             if isinstance(res, Response):
                 # Simply use the response if the controller determines it is ready for use.
-                metadata["number_of_uses"] += 1
-                stored_response.read()
-                await self._storage.store(
-                    key=key,
-                    request=request,
-                    response=stored_response,
-                    metadata=metadata,
+                return await self._create_hishel_response(
+                    key=key, response=stored_response, request=request, metadata=metadata, cached=True
                 )
-                res.extensions["from_cache"] = True  # type: ignore[index]
-                res.extensions["cache_metadata"] = metadata  # type: ignore[index]
-                return res
 
             if request_cache_control.only_if_cached:
                 return generate_504()
@@ -116,9 +110,9 @@ class AsyncCacheConnectionPool(AsyncRequestInterface):
                     response = await self._pool.handle_async_request(res)
                 except ConnectError:
                     if self._controller._allow_stale and allowed_stale(response=stored_response):
-                        stored_response.extensions["from_cache"] = True  # type: ignore[index]
-                        stored_response.extensions["cache_metadata"] = metadata  # type: ignore[index]
-                        return stored_response
+                        return await self._create_hishel_response(
+                            key=key, response=stored_response, request=request, metadata=metadata, cached=True
+                        )
                     raise  # pragma: no cover
                 # Merge headers with the stale response.
                 full_response = self._controller.handle_validation_response(
@@ -126,12 +120,9 @@ class AsyncCacheConnectionPool(AsyncRequestInterface):
                 )
 
                 await full_response.aread()
-                metadata["number_of_uses"] += response.status == 304
-                await self._storage.store(key, response=full_response, request=request, metadata=metadata)
-                full_response.extensions["from_cache"] = response.status == 304  # type: ignore[index]
-                if full_response.extensions["from_cache"]:
-                    full_response.extensions["cache_metadata"] = metadata  # type: ignore[index]
-                return full_response
+                return await self._create_hishel_response(
+                    key=key, response=full_response, request=request, metadata=metadata, cached=response.status == 304
+                )
 
         response = await self._pool.handle_async_request(request)
 
@@ -142,7 +133,25 @@ class AsyncCacheConnectionPool(AsyncRequestInterface):
             )
             await self._storage.store(key, response=response, request=request, metadata=metadata)
 
-        response.extensions["from_cache"] = False  # type: ignore[index]
+        return await self._create_hishel_response(key=key, response=response, request=request, cached=False)
+
+    async def _create_hishel_response(
+        self,
+        key: str,
+        response: Response,
+        request: Request,
+        cached: bool,
+        metadata: Metadata | None = None,
+    ) -> Response:
+        if cached:
+            assert metadata
+            metadata["number_of_uses"] += 1
+            response.read()
+            await self._storage.update_metadata(key=key, request=request, response=response, metadata=metadata)
+            response.extensions["from_cache"] = True  # type: ignore[index]
+            response.extensions["cache_metadata"] = metadata  # type: ignore[index]
+        else:
+            response.extensions["from_cache"] = False  # type: ignore[index]
         return response
 
     async def aclose(self) -> None:

--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import logging
 import os

--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -141,7 +141,7 @@ class AsyncFileStorage(AsyncBaseStorage):
         :param request: An HTTP request
         :type request: httpcore.Request
         :param metadata: Additional information about the stored response
-        :type metadata: Optional[Metadata]
+        :type metadata: Metadata
         """
         response_path = self._base_path / key
 
@@ -288,7 +288,7 @@ class AsyncSQLiteStorage(AsyncBaseStorage):
         :param request: An HTTP request
         :type request: httpcore.Request
         :param metadata: Additional information about the stored response
-        :type metadata: Optional[Metadata]
+        :type metadata: Metadata
         """
 
         await self._setup()
@@ -412,7 +412,7 @@ class AsyncRedisStorage(AsyncBaseStorage):
         :param request: An HTTP request
         :type request: httpcore.Request
         :param metadata: Additional information about the stored response
-        :type metadata: Optional[Metadata]
+        :type metadata: Metadata
         """
 
         ttl_in_milliseconds = await self._client.pttl(key)
@@ -510,7 +510,7 @@ class AsyncInMemoryStorage(AsyncBaseStorage):
         :param request: An HTTP request
         :type request: httpcore.Request
         :param metadata: Additional information about the stored response
-        :type metadata: Optional[Metadata]
+        :type metadata: Metadata
         """
 
         async with self._lock:
@@ -642,7 +642,7 @@ class AsyncS3Storage(AsyncBaseStorage):  # pragma: no cover
         :param request: An HTTP request
         :type request: httpcore.Request
         :param metadata: Additional information about the stored response
-        :type metadata: Optional[Metadata]
+        :type metadata: Metadata
         """
 
         async with self._lock:

--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -521,7 +521,7 @@ class AsyncInMemoryStorage(AsyncBaseStorage):
                 return
             except KeyError:  # pragma: no cover
                 pass
-        await self.store(key, response, request, metadata)
+        await self.store(key, response, request, metadata)  # pragma: no cover
 
     async def retrieve(self, key: str) -> tp.Optional[StoredResponse]:
         """

--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -561,7 +561,7 @@ class AsyncInMemoryStorage(AsyncBaseStorage):
                 self._cache.remove_key(key)
 
 
-class AsyncS3Storage(AsyncBaseStorage):
+class AsyncS3Storage(AsyncBaseStorage):  # pragma: no cover
     """
     AWS S3 storage.
 

--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -158,7 +158,7 @@ class AsyncFileStorage(AsyncBaseStorage):
                 os.utime(response_path, (atime, old_mtime))
                 return
 
-        return await self.store(key, response, request, metadata)
+        return await self.store(key, response, request, metadata)  # pragma: no cover
 
     async def retrieve(self, key: str) -> tp.Optional[StoredResponse]:
         """
@@ -302,7 +302,7 @@ class AsyncSQLiteStorage(AsyncBaseStorage):
                 await self._connection.execute("UPDATE cache SET data = ? WHERE key = ?", [serialized_response, key])
                 await self._connection.commit()
                 return
-        return await self.store(key, response, request, metadata)
+        return await self.store(key, response, request, metadata)  # pragma: no cover
 
     async def retrieve(self, key: str) -> tp.Optional[StoredResponse]:
         """
@@ -417,7 +417,7 @@ class AsyncRedisStorage(AsyncBaseStorage):
 
         ttl_in_milliseconds = await self._client.pttl(key)
 
-        if ttl_in_milliseconds == -2:
+        if ttl_in_milliseconds == -2:  # pragma: no cover
             await self.store(key, response, request, metadata)
         else:
             await self._client.set(
@@ -519,7 +519,7 @@ class AsyncInMemoryStorage(AsyncBaseStorage):
                 stored_response = (stored_response[0], stored_response[1], metadata)
                 self._cache.put(key, (stored_response, created_at))
                 return
-            except KeyError:
+            except KeyError:  # pragma: no cover
                 pass
         await self.store(key, response, request, metadata)
 

--- a/hishel/_async/_transports.py
+++ b/hishel/_async/_transports.py
@@ -123,6 +123,7 @@ class AsyncCacheTransport(httpx.AsyncBaseTransport):
             # Try using the stored response if it was discovered.
 
             stored_response, stored_request, metadata = stored_data
+            stored_response.read()
 
             res = self._controller.construct_response_from_cache(
                 request=httpcore_request,
@@ -225,7 +226,6 @@ class AsyncCacheTransport(httpx.AsyncBaseTransport):
         if cached:
             assert metadata
             metadata["number_of_uses"] += 1
-            response.read()
             await self._storage.update_metadata(key=key, request=request, response=response, metadata=metadata)
             response.extensions["from_cache"] = True  # type: ignore[index]
             response.extensions["cache_metadata"] = metadata  # type: ignore[index]

--- a/hishel/_async/_transports.py
+++ b/hishel/_async/_transports.py
@@ -10,7 +10,7 @@ from hishel._utils import extract_header_values_decoded, normalized_url
 
 from .._controller import Controller, allowed_stale
 from .._headers import parse_cache_control
-from .._serializers import JSONSerializer
+from .._serializers import JSONSerializer, Metadata
 from ._storages import AsyncBaseStorage, AsyncFileStorage
 
 if tp.TYPE_CHECKING:  # pragma: no cover
@@ -130,18 +130,12 @@ class AsyncCacheTransport(httpx.AsyncBaseTransport):
 
             if isinstance(res, httpcore.Response):
                 # Simply use the response if the controller determines it is ready for use.
-                metadata["number_of_uses"] += 1
-                stored_response.read()
-                await self._storage.update_metadata(
-                    key=key, request=stored_request, response=stored_response, metadata=metadata
-                )
-                res.extensions["from_cache"] = True  # type: ignore[index]
-                res.extensions["cache_metadata"] = metadata  # type: ignore[index]
-                return Response(
-                    status_code=res.status,
-                    headers=res.headers,
-                    stream=AsyncCacheStream(fake_stream(stored_response.content)),
-                    extensions=res.extensions,
+                return await self._create_hishel_response(
+                    key=key,
+                    response=res,
+                    request=httpcore_request,
+                    cached=True,
+                    metadata=metadata,
                 )
 
             if request_cache_control.only_if_cached:
@@ -160,14 +154,12 @@ class AsyncCacheTransport(httpx.AsyncBaseTransport):
                     response = await self._transport.handle_async_request(revalidation_request)
                 except ConnectError:
                     if self._controller._allow_stale and allowed_stale(response=stored_response):
-                        await stored_response.aread()
-                        stored_response.extensions["from_cache"] = True  # type: ignore[index]
-                        stored_response.extensions["cache_metadata"] = metadata  # type: ignore[index]
-                        return Response(
-                            status_code=stored_response.status,
-                            headers=stored_response.headers,
-                            stream=AsyncCacheStream(fake_stream(stored_response.content)),
-                            extensions=stored_response.extensions,
+                        return await self._create_hishel_response(
+                            key=key,
+                            response=stored_response,
+                            request=httpcore_request,
+                            cached=True,
+                            metadata=metadata,
                         )
                     raise  # pragma: no cover
                 assert isinstance(response.stream, tp.AsyncIterable)
@@ -186,26 +178,13 @@ class AsyncCacheTransport(httpx.AsyncBaseTransport):
                 await full_response.aread()
                 await response.aclose()
 
-                metadata["number_of_uses"] += response.status_code == 304
-
-                await self._storage.store(
-                    key,
+                assert isinstance(full_response.stream, tp.AsyncIterable)
+                return await self._create_hishel_response(
+                    key=key,
                     response=full_response,
                     request=httpcore_request,
+                    cached=response.status_code == 304,
                     metadata=metadata,
-                )
-
-                assert isinstance(full_response.stream, tp.AsyncIterable)
-                full_response.extensions["from_cache"] = (  # type: ignore[index]
-                    httpcore_response.status == 304
-                )
-                if full_response.extensions["from_cache"]:
-                    full_response.extensions["cache_metadata"] = metadata  # type: ignore[index]
-                return Response(
-                    status_code=full_response.status,
-                    headers=full_response.headers,
-                    stream=AsyncCacheStream(fake_stream(full_response.content)),
-                    extensions=full_response.extensions,
                 )
 
         response = await self._transport.handle_async_request(request)
@@ -226,12 +205,35 @@ class AsyncCacheTransport(httpx.AsyncBaseTransport):
                 request=httpcore_request,
             )
 
-        response.extensions["from_cache"] = False  # type: ignore[index]
+        return await self._create_hishel_response(
+            key=key,
+            response=httpcore_response,
+            request=httpcore_request,
+            cached=False,
+        )
+
+    async def _create_hishel_response(
+        self,
+        key: str,
+        response: httpcore.Response,
+        request: httpcore.Request,
+        cached: bool,
+        metadata: Metadata | None = None,
+    ) -> Response:
+        if cached:
+            assert metadata
+            metadata["number_of_uses"] += 1
+            response.read()
+            await self._storage.update_metadata(key=key, request=request, response=response, metadata=metadata)
+            response.extensions["from_cache"] = True  # type: ignore[index]
+            response.extensions["cache_metadata"] = metadata  # type: ignore[index]
+        else:
+            response.extensions["from_cache"] = False  # type: ignore[index]
         return Response(
-            status_code=httpcore_response.status,
-            headers=httpcore_response.headers,
-            stream=AsyncCacheStream(fake_stream(httpcore_response.content)),
-            extensions=httpcore_response.extensions,
+            status_code=response.status,
+            headers=response.headers,
+            stream=AsyncCacheStream(fake_stream(response.content)),
+            extensions=response.extensions,
         )
 
     async def aclose(self) -> None:

--- a/hishel/_async/_transports.py
+++ b/hishel/_async/_transports.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import types
 import typing as tp
 

--- a/hishel/_s3.py
+++ b/hishel/_s3.py
@@ -5,7 +5,7 @@ from anyio import to_thread
 from botocore.exceptions import ClientError
 
 
-def get_timestamp_in_ms():
+def get_timestamp_in_ms() -> float:
     return time.time() * 1000
 
 

--- a/hishel/_s3.py
+++ b/hishel/_s3.py
@@ -79,7 +79,7 @@ class S3Manager:
                 self._client.delete_object(Bucket=self._bucket_name, Key=obj["Key"])
 
 
-class AsyncS3Manager:
+class AsyncS3Manager:  # pragma: no cover
     def __init__(
         self, client: tp.Any, bucket_name: str, check_ttl_every: tp.Union[int, float], is_binary: bool = False
     ):

--- a/hishel/_sync/_pool.py
+++ b/hishel/_sync/_pool.py
@@ -87,6 +87,7 @@ class CacheConnectionPool(RequestInterface):
             # Try using the stored response if it was discovered.
 
             stored_response, stored_request, metadata = stored_data
+            stored_response.read()
 
             res = self._controller.construct_response_from_cache(
                 request=request,
@@ -125,9 +126,9 @@ class CacheConnectionPool(RequestInterface):
                 )
 
         response = self._pool.handle_request(request)
+        response.read()
 
         if self._controller.is_cachable(request=request, response=response):
-            response.read()
             metadata = Metadata(
                 cache_key=key, created_at=datetime.datetime.now(datetime.timezone.utc), number_of_uses=0
             )
@@ -146,7 +147,6 @@ class CacheConnectionPool(RequestInterface):
         if cached:
             assert metadata
             metadata["number_of_uses"] += 1
-            response.read()
             self._storage.update_metadata(key=key, request=request, response=response, metadata=metadata)
             response.extensions["from_cache"] = True  # type: ignore[index]
             response.extensions["cache_metadata"] = metadata  # type: ignore[index]

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import logging
 import os

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -521,7 +521,7 @@ class InMemoryStorage(BaseStorage):
                 return
             except KeyError:  # pragma: no cover
                 pass
-        self.store(key, response, request, metadata)
+        self.store(key, response, request, metadata)  # pragma: no cover
 
     def retrieve(self, key: str) -> tp.Optional[StoredResponse]:
         """

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -158,7 +158,7 @@ class FileStorage(BaseStorage):
                 os.utime(response_path, (atime, old_mtime))
                 return
 
-        return self.store(key, response, request, metadata)
+        return self.store(key, response, request, metadata)  # pragma: no cover
 
     def retrieve(self, key: str) -> tp.Optional[StoredResponse]:
         """
@@ -302,7 +302,7 @@ class SQLiteStorage(BaseStorage):
                 self._connection.execute("UPDATE cache SET data = ? WHERE key = ?", [serialized_response, key])
                 self._connection.commit()
                 return
-        return self.store(key, response, request, metadata)
+        return self.store(key, response, request, metadata)  # pragma: no cover
 
     def retrieve(self, key: str) -> tp.Optional[StoredResponse]:
         """
@@ -417,7 +417,7 @@ class RedisStorage(BaseStorage):
 
         ttl_in_milliseconds = self._client.pttl(key)
 
-        if ttl_in_milliseconds == -2:
+        if ttl_in_milliseconds == -2:  # pragma: no cover
             self.store(key, response, request, metadata)
         else:
             self._client.set(
@@ -519,7 +519,7 @@ class InMemoryStorage(BaseStorage):
                 stored_response = (stored_response[0], stored_response[1], metadata)
                 self._cache.put(key, (stored_response, created_at))
                 return
-            except KeyError:
+            except KeyError:  # pragma: no cover
                 pass
         self.store(key, response, request, metadata)
 

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -141,7 +141,7 @@ class FileStorage(BaseStorage):
         :param request: An HTTP request
         :type request: httpcore.Request
         :param metadata: Additional information about the stored response
-        :type metadata: Optional[Metadata]
+        :type metadata: Metadata
         """
         response_path = self._base_path / key
 
@@ -288,7 +288,7 @@ class SQLiteStorage(BaseStorage):
         :param request: An HTTP request
         :type request: httpcore.Request
         :param metadata: Additional information about the stored response
-        :type metadata: Optional[Metadata]
+        :type metadata: Metadata
         """
 
         self._setup()
@@ -412,7 +412,7 @@ class RedisStorage(BaseStorage):
         :param request: An HTTP request
         :type request: httpcore.Request
         :param metadata: Additional information about the stored response
-        :type metadata: Optional[Metadata]
+        :type metadata: Metadata
         """
 
         ttl_in_milliseconds = self._client.pttl(key)
@@ -510,7 +510,7 @@ class InMemoryStorage(BaseStorage):
         :param request: An HTTP request
         :type request: httpcore.Request
         :param metadata: Additional information about the stored response
-        :type metadata: Optional[Metadata]
+        :type metadata: Metadata
         """
 
         with self._lock:
@@ -642,7 +642,7 @@ class S3Storage(BaseStorage):  # pragma: no cover
         :param request: An HTTP request
         :type request: httpcore.Request
         :param metadata: Additional information about the stored response
-        :type metadata: Optional[Metadata]
+        :type metadata: Metadata
         """
 
         with self._lock:

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -1,4 +1,6 @@
+import datetime
 import logging
+import os
 import time
 import typing as tp
 import warnings
@@ -48,7 +50,10 @@ class BaseStorage:
         self._serializer = serializer or JSONSerializer()
         self._ttl = ttl
 
-    def store(self, key: str, response: Response, request: Request, metadata: Metadata) -> None:
+    def store(self, key: str, response: Response, request: Request, metadata: Metadata | None = None) -> None:
+        raise NotImplementedError()
+
+    def update_metadata(self, key: str, response: Response, request: Request, metadata: Metadata) -> None:
         raise NotImplementedError()
 
     def retrieve(self, key: str) -> tp.Optional[StoredResponse]:
@@ -97,7 +102,7 @@ class FileStorage(BaseStorage):
         self._check_ttl_every = check_ttl_every
         self._last_cleaned = time.monotonic()
 
-    def store(self, key: str, response: Response, request: Request, metadata: Metadata) -> None:
+    def store(self, key: str, response: Response, request: Request, metadata: Metadata | None = None) -> None:
         """
         Stores the response in the cache.
 
@@ -108,8 +113,12 @@ class FileStorage(BaseStorage):
         :param request: An HTTP request
         :type request: httpcore.Request
         :param metadata: Additional information about the stored response
-        :type metadata: Metadata
+        :type metadata: Optional[Metadata]
         """
+
+        metadata = metadata or Metadata(
+            cache_key=key, created_at=datetime.datetime.now(datetime.timezone.utc), number_of_uses=0
+        )
         response_path = self._base_path / key
 
         with self._lock:
@@ -118,6 +127,36 @@ class FileStorage(BaseStorage):
                 self._serializer.dumps(response=response, request=request, metadata=metadata),
             )
         self._remove_expired_caches(response_path)
+
+    def update_metadata(self, key: str, response: Response, request: Request, metadata: Metadata) -> None:
+        """
+        Updates the metadata of the stored response.
+
+        :param key: Hashed value of concatenated HTTP method and URI
+        :type key: str
+        :param response: An HTTP response
+        :type response: httpcore.Response
+        :param request: An HTTP request
+        :type request: httpcore.Request
+        :param metadata: Additional information about the stored response
+        :type metadata: Optional[Metadata]
+        """
+        response_path = self._base_path / key
+
+        with self._lock:
+            if response_path.exists():
+                atime = response_path.stat().st_atime
+                old_mtime = response_path.stat().st_mtime
+                self._file_manager.write_to(
+                    str(response_path),
+                    self._serializer.dumps(response=response, request=request, metadata=metadata),
+                )
+
+                # Restore the old atime and mtime (we use mtime to check the cache expiration time)
+                os.utime(response_path, (atime, old_mtime))
+                return
+
+        return self.store(key, response, request, metadata)
 
     def retrieve(self, key: str) -> tp.Optional[StoredResponse]:
         """
@@ -206,7 +245,7 @@ class SQLiteStorage(BaseStorage):
                 self._connection.commit()
                 self._setup_completed = True
 
-    def store(self, key: str, response: Response, request: Request, metadata: Metadata) -> None:
+    def store(self, key: str, response: Response, request: Request, metadata: Metadata | None = None) -> None:
         """
         Stores the response in the cache.
 
@@ -217,11 +256,15 @@ class SQLiteStorage(BaseStorage):
         :param request: An HTTP request
         :type request: httpcore.Request
         :param metadata: Additioal information about the stored response
-        :type metadata: Metadata
+        :type metadata: Optional[Metadata]
         """
 
         self._setup()
         assert self._connection
+
+        metadata = metadata or Metadata(
+            cache_key=key, created_at=datetime.datetime.now(datetime.timezone.utc), number_of_uses=0
+        )
 
         with self._lock:
             self._connection.execute("DELETE FROM cache WHERE key = ?", [key])
@@ -231,6 +274,33 @@ class SQLiteStorage(BaseStorage):
             )
             self._connection.commit()
         self._remove_expired_caches()
+
+    def update_metadata(self, key: str, response: Response, request: Request, metadata: Metadata) -> None:
+        """
+        Updates the metadata of the stored response.
+
+        :param key: Hashed value of concatenated HTTP method and URI
+        :type key: str
+        :param response: An HTTP response
+        :type response: httpcore.Response
+        :param request: An HTTP request
+        :type request: httpcore.Request
+        :param metadata: Additional information about the stored response
+        :type metadata: Optional[Metadata]
+        """
+
+        self._setup()
+        assert self._connection
+
+        with self._lock:
+            cursor = self._connection.execute("SELECT data FROM cache WHERE key = ?", [key])
+            row = cursor.fetchone()
+            if row is not None:
+                serialized_response = self._serializer.dumps(response=response, request=request, metadata=metadata)
+                self._connection.execute("UPDATE cache SET data = ? WHERE key = ?", [serialized_response, key])
+                self._connection.commit()
+                return
+        return self.store(key, response, request, metadata)
 
     def retrieve(self, key: str) -> tp.Optional[StoredResponse]:
         """
@@ -302,7 +372,7 @@ class RedisStorage(BaseStorage):
         else:  # pragma: no cover
             self._client = client
 
-    def store(self, key: str, response: Response, request: Request, metadata: Metadata) -> None:
+    def store(self, key: str, response: Response, request: Request, metadata: Metadata | None = None) -> None:
         """
         Stores the response in the cache.
 
@@ -313,8 +383,12 @@ class RedisStorage(BaseStorage):
         :param request: An HTTP request
         :type request: httpcore.Request
         :param metadata: Additioal information about the stored response
-        :type metadata: Metadata
+        :type metadata: Optional[Metadata]
         """
+
+        metadata = metadata or Metadata(
+            cache_key=key, created_at=datetime.datetime.now(datetime.timezone.utc), number_of_uses=0
+        )
 
         if self._ttl is not None:
             px = float_seconds_to_int_milliseconds(self._ttl)
@@ -324,6 +398,31 @@ class RedisStorage(BaseStorage):
         self._client.set(
             key, self._serializer.dumps(response=response, request=request, metadata=metadata), px=px
         )
+
+    def update_metadata(self, key: str, response: Response, request: Request, metadata: Metadata) -> None:
+        """
+        Updates the metadata of the stored response.
+
+        :param key: Hashed value of concatenated HTTP method and URI
+        :type key: str
+        :param response: An HTTP response
+        :type response: httpcore.Response
+        :param request: An HTTP request
+        :type request: httpcore.Request
+        :param metadata: Additional information about the stored response
+        :type metadata: Optional[Metadata]
+        """
+
+        ttl_in_milliseconds = self._client.pttl(key)
+
+        if ttl_in_milliseconds == -2:
+            self.store(key, response, request, metadata)
+        else:
+            self._client.set(
+                key,
+                self._serializer.dumps(response=response, request=request, metadata=metadata),
+                px=ttl_in_milliseconds,
+            )
 
     def retrieve(self, key: str) -> tp.Optional[StoredResponse]:
         """
@@ -373,7 +472,7 @@ class InMemoryStorage(BaseStorage):
         self._cache: LFUCache[str, tp.Tuple[StoredResponse, float]] = LFUCache(capacity=capacity)
         self._lock = Lock()
 
-    def store(self, key: str, response: Response, request: Request, metadata: Metadata) -> None:
+    def store(self, key: str, response: Response, request: Request, metadata: Metadata | None = None) -> None:
         """
         Stores the response in the cache.
 
@@ -384,8 +483,12 @@ class InMemoryStorage(BaseStorage):
         :param request: An HTTP request
         :type request: httpcore.Request
         :param metadata: Additioal information about the stored response
-        :type metadata: Metadata
+        :type metadata: Optional[Metadata]
         """
+
+        metadata = metadata or Metadata(
+            cache_key=key, created_at=datetime.datetime.now(datetime.timezone.utc), number_of_uses=0
+        )
 
         with self._lock:
             response_clone = clone_model(response)
@@ -393,6 +496,30 @@ class InMemoryStorage(BaseStorage):
             stored_response: StoredResponse = (deepcopy(response_clone), deepcopy(request_clone), metadata)
             self._cache.put(key, (stored_response, time.monotonic()))
         self._remove_expired_caches()
+
+    def update_metadata(self, key: str, response: Response, request: Request, metadata: Metadata) -> None:
+        """
+        Updates the metadata of the stored response.
+
+        :param key: Hashed value of concatenated HTTP method and URI
+        :type key: str
+        :param response: An HTTP response
+        :type response: httpcore.Response
+        :param request: An HTTP request
+        :type request: httpcore.Request
+        :param metadata: Additional information about the stored response
+        :type metadata: Optional[Metadata]
+        """
+
+        with self._lock:
+            try:
+                stored_response, created_at = self._cache.get(key)
+                stored_response = (stored_response[0], stored_response[1], metadata)
+                self._cache.put(key, (stored_response, created_at))
+                return
+            except KeyError:
+                pass
+        self.store(key, response, request, metadata)
 
     def retrieve(self, key: str) -> tp.Optional[StoredResponse]:
         """
@@ -478,7 +605,7 @@ class S3Storage(BaseStorage):
         )
         self._lock = Lock()
 
-    def store(self, key: str, response: Response, request: Request, metadata: Metadata) -> None:
+    def store(self, key: str, response: Response, request: Request, metadata: Metadata | None = None) -> None:
         """
         Stores the response in the cache.
 
@@ -489,14 +616,36 @@ class S3Storage(BaseStorage):
         :param request: An HTTP request
         :type request: httpcore.Request
         :param metadata: Additioal information about the stored response
-        :type metadata: Metadata`
+        :type metadata: Optional[Metadata]`
         """
+
+        metadata = metadata or Metadata(
+            cache_key=key, created_at=datetime.datetime.now(datetime.timezone.utc), number_of_uses=0
+        )
 
         with self._lock:
             serialized = self._serializer.dumps(response=response, request=request, metadata=metadata)
             self._s3_manager.write_to(path=key, data=serialized)
 
         self._remove_expired_caches(key)
+
+    def update_metadata(self, key: str, response: Response, request: Request, metadata: Metadata) -> None:
+        """
+        Updates the metadata of the stored response.
+
+        :param key: Hashed value of concatenated HTTP method and URI
+        :type key: str
+        :param response: An HTTP response
+        :type response: httpcore.Response
+        :param request: An HTTP request
+        :type request: httpcore.Request
+        :param metadata: Additional information about the stored response
+        :type metadata: Optional[Metadata]
+        """
+
+        with self._lock:
+            serialized = self._serializer.dumps(response=response, request=request, metadata=metadata)
+            self._s3_manager.write_to(path=key, data=serialized, only_metadata=True)
 
     def retrieve(self, key: str) -> tp.Optional[StoredResponse]:
         """

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -561,7 +561,7 @@ class InMemoryStorage(BaseStorage):
                 self._cache.remove_key(key)
 
 
-class S3Storage(BaseStorage):
+class S3Storage(BaseStorage):  # pragma: no cover
     """
     AWS S3 storage.
 

--- a/hishel/_sync/_transports.py
+++ b/hishel/_sync/_transports.py
@@ -10,7 +10,7 @@ from hishel._utils import extract_header_values_decoded, normalized_url
 
 from .._controller import Controller, allowed_stale
 from .._headers import parse_cache_control
-from .._serializers import JSONSerializer
+from .._serializers import JSONSerializer, Metadata
 from ._storages import BaseStorage, FileStorage
 
 if tp.TYPE_CHECKING:  # pragma: no cover
@@ -130,18 +130,12 @@ class CacheTransport(httpx.BaseTransport):
 
             if isinstance(res, httpcore.Response):
                 # Simply use the response if the controller determines it is ready for use.
-                metadata["number_of_uses"] += 1
-                stored_response.read()
-                self._storage.update_metadata(
-                    key=key, request=stored_request, response=stored_response, metadata=metadata
-                )
-                res.extensions["from_cache"] = True  # type: ignore[index]
-                res.extensions["cache_metadata"] = metadata  # type: ignore[index]
-                return Response(
-                    status_code=res.status,
-                    headers=res.headers,
-                    stream=CacheStream(fake_stream(stored_response.content)),
-                    extensions=res.extensions,
+                return self._create_hishel_response(
+                    key=key,
+                    response=res,
+                    request=httpcore_request,
+                    cached=True,
+                    metadata=metadata,
                 )
 
             if request_cache_control.only_if_cached:
@@ -160,14 +154,12 @@ class CacheTransport(httpx.BaseTransport):
                     response = self._transport.handle_request(revalidation_request)
                 except ConnectError:
                     if self._controller._allow_stale and allowed_stale(response=stored_response):
-                        stored_response.read()
-                        stored_response.extensions["from_cache"] = True  # type: ignore[index]
-                        stored_response.extensions["cache_metadata"] = metadata  # type: ignore[index]
-                        return Response(
-                            status_code=stored_response.status,
-                            headers=stored_response.headers,
-                            stream=CacheStream(fake_stream(stored_response.content)),
-                            extensions=stored_response.extensions,
+                        return self._create_hishel_response(
+                            key=key,
+                            response=stored_response,
+                            request=httpcore_request,
+                            cached=True,
+                            metadata=metadata,
                         )
                     raise  # pragma: no cover
                 assert isinstance(response.stream, tp.Iterable)
@@ -186,26 +178,13 @@ class CacheTransport(httpx.BaseTransport):
                 full_response.read()
                 response.close()
 
-                metadata["number_of_uses"] += response.status_code == 304
-
-                self._storage.store(
-                    key,
+                assert isinstance(full_response.stream, tp.Iterable)
+                return self._create_hishel_response(
+                    key=key,
                     response=full_response,
                     request=httpcore_request,
+                    cached=response.status_code == 304,
                     metadata=metadata,
-                )
-
-                assert isinstance(full_response.stream, tp.Iterable)
-                full_response.extensions["from_cache"] = (  # type: ignore[index]
-                    httpcore_response.status == 304
-                )
-                if full_response.extensions["from_cache"]:
-                    full_response.extensions["cache_metadata"] = metadata  # type: ignore[index]
-                return Response(
-                    status_code=full_response.status,
-                    headers=full_response.headers,
-                    stream=CacheStream(fake_stream(full_response.content)),
-                    extensions=full_response.extensions,
                 )
 
         response = self._transport.handle_request(request)
@@ -226,12 +205,35 @@ class CacheTransport(httpx.BaseTransport):
                 request=httpcore_request,
             )
 
-        response.extensions["from_cache"] = False  # type: ignore[index]
+        return self._create_hishel_response(
+            key=key,
+            response=httpcore_response,
+            request=httpcore_request,
+            cached=False,
+        )
+
+    def _create_hishel_response(
+        self,
+        key: str,
+        response: httpcore.Response,
+        request: httpcore.Request,
+        cached: bool,
+        metadata: Metadata | None = None,
+    ) -> Response:
+        if cached:
+            assert metadata
+            metadata["number_of_uses"] += 1
+            response.read()
+            self._storage.update_metadata(key=key, request=request, response=response, metadata=metadata)
+            response.extensions["from_cache"] = True  # type: ignore[index]
+            response.extensions["cache_metadata"] = metadata  # type: ignore[index]
+        else:
+            response.extensions["from_cache"] = False  # type: ignore[index]
         return Response(
-            status_code=httpcore_response.status,
-            headers=httpcore_response.headers,
-            stream=CacheStream(fake_stream(httpcore_response.content)),
-            extensions=httpcore_response.extensions,
+            status_code=response.status,
+            headers=response.headers,
+            stream=CacheStream(fake_stream(response.content)),
+            extensions=response.extensions,
         )
 
     def close(self) -> None:

--- a/hishel/_sync/_transports.py
+++ b/hishel/_sync/_transports.py
@@ -1,4 +1,3 @@
-import datetime
 import types
 import typing as tp
 
@@ -11,7 +10,7 @@ from hishel._utils import extract_header_values_decoded, normalized_url
 
 from .._controller import Controller, allowed_stale
 from .._headers import parse_cache_control
-from .._serializers import JSONSerializer, Metadata
+from .._serializers import JSONSerializer
 from ._storages import BaseStorage, FileStorage
 
 if tp.TYPE_CHECKING:  # pragma: no cover
@@ -133,11 +132,8 @@ class CacheTransport(httpx.BaseTransport):
                 # Simply use the response if the controller determines it is ready for use.
                 metadata["number_of_uses"] += 1
                 stored_response.read()
-                self._storage.store(
-                    key=key,
-                    request=stored_request,
-                    response=stored_response,
-                    metadata=metadata,
+                self._storage.update_metadata(
+                    key=key, request=stored_request, response=stored_response, metadata=metadata
                 )
                 res.extensions["from_cache"] = True  # type: ignore[index]
                 res.extensions["cache_metadata"] = metadata  # type: ignore[index]
@@ -224,14 +220,10 @@ class CacheTransport(httpx.BaseTransport):
         httpcore_response.close()
 
         if self._controller.is_cachable(request=httpcore_request, response=httpcore_response):
-            metadata = Metadata(
-                cache_key=key, created_at=datetime.datetime.now(datetime.timezone.utc), number_of_uses=0
-            )
             self._storage.store(
                 key,
                 response=httpcore_response,
                 request=httpcore_request,
-                metadata=metadata,
             )
 
         response.extensions["from_cache"] = False  # type: ignore[index]

--- a/hishel/_sync/_transports.py
+++ b/hishel/_sync/_transports.py
@@ -123,6 +123,7 @@ class CacheTransport(httpx.BaseTransport):
             # Try using the stored response if it was discovered.
 
             stored_response, stored_request, metadata = stored_data
+            stored_response.read()
 
             res = self._controller.construct_response_from_cache(
                 request=httpcore_request,
@@ -225,7 +226,6 @@ class CacheTransport(httpx.BaseTransport):
         if cached:
             assert metadata
             metadata["number_of_uses"] += 1
-            response.read()
             self._storage.update_metadata(key=key, request=request, response=response, metadata=metadata)
             response.extensions["from_cache"] = True  # type: ignore[index]
             response.extensions["cache_metadata"] = metadata  # type: ignore[index]

--- a/hishel/_sync/_transports.py
+++ b/hishel/_sync/_transports.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import types
 import typing as tp
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ anyio==4.3.0
 trio==0.24.0
 coverage==7.4.1
 types-PyYAML==6.0.12.12
-moto[s3]==4.2.14
 
 # build
 hatch==1.7.0

--- a/tests/_async/test_storages.py
+++ b/tests/_async/test_storages.py
@@ -3,12 +3,10 @@ import os
 from pathlib import Path
 
 import anysqlite
-import boto3
 import pytest
 from httpcore import Request, Response
-from moto import mock_s3
 
-from hishel import AsyncFileStorage, AsyncInMemoryStorage, AsyncRedisStorage, AsyncS3Storage, AsyncSQLiteStorage
+from hishel import AsyncFileStorage, AsyncInMemoryStorage, AsyncRedisStorage, AsyncSQLiteStorage
 from hishel._serializers import Metadata
 from hishel._utils import asleep, generate_key
 
@@ -25,50 +23,9 @@ async def is_redis_down() -> bool:
         return True
 
 
-@pytest.fixture(scope="function")
-def aws_credentials():
-    """Mocked AWS Credentials for moto."""
-
-    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
-    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
-    os.environ["AWS_SECURITY_TOKEN"] = "testing"
-    os.environ["AWS_SESSION_TOKEN"] = "testing"
-    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
-
-
-@pytest.fixture(scope="function")
-def s3(aws_credentials):
-    with mock_s3():
-        yield boto3.client("s3", region_name="us-east-1")
-
-
 @pytest.mark.anyio
 async def test_filestorage(use_temp_dir):
     storage = AsyncFileStorage()
-
-    request = Request(b"GET", "https://example.com")
-
-    key = generate_key(request)
-
-    response = Response(200, headers=[], content=b"test")
-    await response.aread()
-
-    await storage.store(key, response=response, request=request, metadata=dummy_metadata)
-
-    stored_data = await storage.retrieve(key)
-    assert stored_data is not None
-    stored_response, stored_request, metadata = stored_data
-    stored_response.read()
-    assert isinstance(stored_response, Response)
-    assert stored_response.status == 200
-    assert stored_response.headers == []
-    assert stored_response.content == b"test"
-
-
-@pytest.mark.anyio
-async def test_s3storage(use_temp_dir, s3):
-    boto3.client("s3").create_bucket(Bucket="testBucket")
-    storage = AsyncS3Storage(bucket_name="testBucket")
 
     request = Request(b"GET", "https://example.com")
 
@@ -176,29 +133,6 @@ async def test_filestorage_expired(use_temp_dir, anyio_backend):
     assert await storage.retrieve(first_key) is not None
 
     await asleep(0.3)
-    await storage.store(second_key, response=response, request=second_request, metadata=dummy_metadata)
-
-    assert await storage.retrieve(first_key) is None
-
-
-@pytest.mark.parametrize("anyio_backend", ["asyncio"])
-async def test_s3storage_expired(use_temp_dir, s3, anyio_backend):
-    boto3.client("s3").create_bucket(Bucket="testBucket")
-    storage = AsyncS3Storage(bucket_name="testBucket", ttl=3)
-
-    first_request = Request(b"GET", "https://example.com")
-    second_request = Request(b"GET", "https://anotherexample.com")
-
-    first_key = generate_key(first_request)
-    second_key = generate_key(second_request)
-
-    response = Response(200, headers=[], content=b"test")
-    await response.aread()
-
-    await storage.store(first_key, response=response, request=first_request, metadata=dummy_metadata)
-    assert await storage.retrieve(first_key) is not None
-
-    await asleep(3)
     await storage.store(second_key, response=response, request=second_request, metadata=dummy_metadata)
 
     assert await storage.retrieve(first_key) is None
@@ -316,42 +250,3 @@ async def test_filestorage_empty_file_exception(use_temp_dir):
         file.truncate(0)
     assert os.path.getsize(filedir) == 0
     assert await storage.retrieve(key) is None
-
-
-@pytest.mark.anyio
-async def test_s3storage_timer(use_temp_dir, s3):
-    boto3.client("s3").create_bucket(Bucket="testBucket")
-    storage = AsyncS3Storage(bucket_name="testBucket", ttl=5, check_ttl_every=5)
-
-    first_request = Request(b"GET", "https://example.com")
-    second_request = Request(b"GET", "https://anotherexample.com")
-
-    first_key = generate_key(first_request)
-    second_key = generate_key(second_request)
-
-    response = Response(200, headers=[], content=b"test")
-    await response.aread()
-
-    await storage.store(first_key, response=response, request=first_request, metadata=dummy_metadata)
-    assert await storage.retrieve(first_key) is not None
-    await asleep(3)
-    assert await storage.retrieve(first_key) is not None
-    await storage.store(second_key, response=response, request=second_request, metadata=dummy_metadata)
-    assert await storage.retrieve(second_key) is not None
-    await asleep(2)
-    assert await storage.retrieve(first_key) is None
-    assert await storage.retrieve(second_key) is not None
-    await asleep(3)
-    assert await storage.retrieve(second_key) is None
-
-
-@pytest.mark.anyio
-async def test_s3storage_key_error(use_temp_dir, s3):
-    """Triggers `NoSuchKey` error."""
-
-    boto3.client("s3").create_bucket(Bucket="testBucket")
-    storage = AsyncS3Storage(bucket_name="testBucket", ttl=60)
-    first_request = Request(b"GET", "https://example.com")
-    first_key = generate_key(first_request)
-
-    assert await storage.retrieve(first_key) is None

--- a/tests/_async/test_storages.py
+++ b/tests/_async/test_storages.py
@@ -165,6 +165,36 @@ async def test_filestorage_timer(use_temp_dir, anyio_backend):
 
 
 @pytest.mark.parametrize("anyio_backend", ["asyncio"])
+async def test_filestorage_ttl_after_hits(use_temp_dir, anyio_backend):
+    storage = AsyncFileStorage(ttl=0.2, check_ttl_every=0.2)
+
+    request = Request(b"GET", "https://example.com")
+
+    key = generate_key(request)
+
+    response = Response(200, headers=[], content=b"test")
+    await response.aread()
+
+    # Storing
+    await storage.store(key, response=response, request=request, metadata=dummy_metadata)
+    assert await storage.retrieve(key) is not None
+
+    # Retrieving after 0.08 second
+    await asleep(0.08)
+    await storage.update_metadata(key, response=response, request=request, metadata=dummy_metadata)
+    assert await storage.retrieve(key) is not None
+
+    # Retrieving after 0.16 second
+    await asleep(0.08)
+    await storage.update_metadata(key, response=response, request=request, metadata=dummy_metadata)
+    assert await storage.retrieve(key) is not None
+
+    # Retrieving after 0.24 second
+    await asleep(0.08)
+    assert await storage.retrieve(key) is None
+
+
+@pytest.mark.parametrize("anyio_backend", ["asyncio"])
 async def test_redisstorage_expired(anyio_backend):
     if await is_redis_down():  # pragma: no cover
         pytest.fail("Redis server was not found")
@@ -185,6 +215,36 @@ async def test_redisstorage_expired(anyio_backend):
     await storage.store(second_key, response=response, request=second_request, metadata=dummy_metadata)
 
     assert await storage.retrieve(first_key) is None
+
+
+@pytest.mark.parametrize("anyio_backend", ["asyncio"])
+async def test_redis_ttl_after_hits(use_temp_dir, anyio_backend):
+    storage = AsyncRedisStorage(ttl=0.2)
+
+    request = Request(b"GET", "https://example.com")
+
+    key = generate_key(request)
+
+    response = Response(200, headers=[], content=b"test")
+    await response.aread()
+
+    # Storing
+    await storage.store(key, response=response, request=request, metadata=dummy_metadata)
+    assert await storage.retrieve(key) is not None
+
+    # Retrieving after 0.08 second
+    await asleep(0.08)
+    await storage.update_metadata(key, response=response, request=request, metadata=dummy_metadata)
+    assert await storage.retrieve(key) is not None
+
+    # Retrieving after 0.16 second
+    await asleep(0.08)
+    await storage.update_metadata(key, response=response, request=request, metadata=dummy_metadata)
+    assert await storage.retrieve(key) is not None
+
+    # Retrieving after 0.24 second
+    await asleep(0.08)
+    assert await storage.retrieve(key) is None
 
 
 @pytest.mark.parametrize("anyio_backend", ["asyncio"])
@@ -209,6 +269,36 @@ async def test_sqlite_expired(anyio_backend):
 
 
 @pytest.mark.parametrize("anyio_backend", ["asyncio"])
+async def test_sqlite_ttl_after_hits(use_temp_dir, anyio_backend):
+    storage = AsyncSQLiteStorage(ttl=0.2)
+
+    request = Request(b"GET", "https://example.com")
+
+    key = generate_key(request)
+
+    response = Response(200, headers=[], content=b"test")
+    await response.aread()
+
+    # Storing
+    await storage.store(key, response=response, request=request, metadata=dummy_metadata)
+    assert await storage.retrieve(key) is not None
+
+    # Retrieving after 0.08 second
+    await asleep(0.08)
+    await storage.update_metadata(key, response=response, request=request, metadata=dummy_metadata)
+    assert await storage.retrieve(key) is not None
+
+    # Retrieving after 0.16 second
+    await asleep(0.08)
+    await storage.update_metadata(key, response=response, request=request, metadata=dummy_metadata)
+    assert await storage.retrieve(key) is not None
+
+    # Retrieving after 0.24 second
+    await asleep(0.08)
+    assert await storage.retrieve(key) is None
+
+
+@pytest.mark.parametrize("anyio_backend", ["asyncio"])
 async def test_inmemory_expired(anyio_backend):
     storage = AsyncInMemoryStorage(ttl=0.1)
     first_request = Request(b"GET", "https://example.com")
@@ -227,6 +317,36 @@ async def test_inmemory_expired(anyio_backend):
     await storage.store(second_key, response=response, request=second_request, metadata=dummy_metadata)
 
     assert await storage.retrieve(first_key) is None
+
+
+@pytest.mark.parametrize("anyio_backend", ["asyncio"])
+async def test_inmemory_ttl_after_hits(use_temp_dir, anyio_backend):
+    storage = AsyncInMemoryStorage(ttl=0.2)
+
+    request = Request(b"GET", "https://example.com")
+
+    key = generate_key(request)
+
+    response = Response(200, headers=[], content=b"test")
+    await response.aread()
+
+    # Storing
+    await storage.store(key, response=response, request=request, metadata=dummy_metadata)
+    assert await storage.retrieve(key) is not None
+
+    # Retrieving after 0.08 second
+    await asleep(0.08)
+    await storage.update_metadata(key, response=response, request=request, metadata=dummy_metadata)
+    assert await storage.retrieve(key) is not None
+
+    # Retrieving after 0.16 second
+    await asleep(0.08)
+    await storage.update_metadata(key, response=response, request=request, metadata=dummy_metadata)
+    assert await storage.retrieve(key) is not None
+
+    # Retrieving after 0.24 second
+    await asleep(0.08)
+    assert await storage.retrieve(key) is None
 
 
 @pytest.mark.anyio

--- a/tests/_sync/test_storages.py
+++ b/tests/_sync/test_storages.py
@@ -165,6 +165,36 @@ def test_filestorage_timer(use_temp_dir, anyio_backend):
 
 
 
+def test_filestorage_ttl_after_hits(use_temp_dir, anyio_backend):
+    storage = FileStorage(ttl=0.2, check_ttl_every=0.2)
+
+    request = Request(b"GET", "https://example.com")
+
+    key = generate_key(request)
+
+    response = Response(200, headers=[], content=b"test")
+    response.read()
+
+    # Storing
+    storage.store(key, response=response, request=request, metadata=dummy_metadata)
+    assert storage.retrieve(key) is not None
+
+    # Retrieving after 0.08 second
+    sleep(0.08)
+    storage.update_metadata(key, response=response, request=request, metadata=dummy_metadata)
+    assert storage.retrieve(key) is not None
+
+    # Retrieving after 0.16 second
+    sleep(0.08)
+    storage.update_metadata(key, response=response, request=request, metadata=dummy_metadata)
+    assert storage.retrieve(key) is not None
+
+    # Retrieving after 0.24 second
+    sleep(0.08)
+    assert storage.retrieve(key) is None
+
+
+
 def test_redisstorage_expired(anyio_backend):
     if is_redis_down():  # pragma: no cover
         pytest.fail("Redis server was not found")
@@ -185,6 +215,36 @@ def test_redisstorage_expired(anyio_backend):
     storage.store(second_key, response=response, request=second_request, metadata=dummy_metadata)
 
     assert storage.retrieve(first_key) is None
+
+
+
+def test_redis_ttl_after_hits(use_temp_dir, anyio_backend):
+    storage = RedisStorage(ttl=0.2)
+
+    request = Request(b"GET", "https://example.com")
+
+    key = generate_key(request)
+
+    response = Response(200, headers=[], content=b"test")
+    response.read()
+
+    # Storing
+    storage.store(key, response=response, request=request, metadata=dummy_metadata)
+    assert storage.retrieve(key) is not None
+
+    # Retrieving after 0.08 second
+    sleep(0.08)
+    storage.update_metadata(key, response=response, request=request, metadata=dummy_metadata)
+    assert storage.retrieve(key) is not None
+
+    # Retrieving after 0.16 second
+    sleep(0.08)
+    storage.update_metadata(key, response=response, request=request, metadata=dummy_metadata)
+    assert storage.retrieve(key) is not None
+
+    # Retrieving after 0.24 second
+    sleep(0.08)
+    assert storage.retrieve(key) is None
 
 
 
@@ -209,6 +269,36 @@ def test_sqlite_expired(anyio_backend):
 
 
 
+def test_sqlite_ttl_after_hits(use_temp_dir, anyio_backend):
+    storage = SQLiteStorage(ttl=0.2)
+
+    request = Request(b"GET", "https://example.com")
+
+    key = generate_key(request)
+
+    response = Response(200, headers=[], content=b"test")
+    response.read()
+
+    # Storing
+    storage.store(key, response=response, request=request, metadata=dummy_metadata)
+    assert storage.retrieve(key) is not None
+
+    # Retrieving after 0.08 second
+    sleep(0.08)
+    storage.update_metadata(key, response=response, request=request, metadata=dummy_metadata)
+    assert storage.retrieve(key) is not None
+
+    # Retrieving after 0.16 second
+    sleep(0.08)
+    storage.update_metadata(key, response=response, request=request, metadata=dummy_metadata)
+    assert storage.retrieve(key) is not None
+
+    # Retrieving after 0.24 second
+    sleep(0.08)
+    assert storage.retrieve(key) is None
+
+
+
 def test_inmemory_expired(anyio_backend):
     storage = InMemoryStorage(ttl=0.1)
     first_request = Request(b"GET", "https://example.com")
@@ -227,6 +317,36 @@ def test_inmemory_expired(anyio_backend):
     storage.store(second_key, response=response, request=second_request, metadata=dummy_metadata)
 
     assert storage.retrieve(first_key) is None
+
+
+
+def test_inmemory_ttl_after_hits(use_temp_dir, anyio_backend):
+    storage = InMemoryStorage(ttl=0.2)
+
+    request = Request(b"GET", "https://example.com")
+
+    key = generate_key(request)
+
+    response = Response(200, headers=[], content=b"test")
+    response.read()
+
+    # Storing
+    storage.store(key, response=response, request=request, metadata=dummy_metadata)
+    assert storage.retrieve(key) is not None
+
+    # Retrieving after 0.08 second
+    sleep(0.08)
+    storage.update_metadata(key, response=response, request=request, metadata=dummy_metadata)
+    assert storage.retrieve(key) is not None
+
+    # Retrieving after 0.16 second
+    sleep(0.08)
+    storage.update_metadata(key, response=response, request=request, metadata=dummy_metadata)
+    assert storage.retrieve(key) is not None
+
+    # Retrieving after 0.24 second
+    sleep(0.08)
+    assert storage.retrieve(key) is None
 
 
 

--- a/tests/_sync/test_storages.py
+++ b/tests/_sync/test_storages.py
@@ -3,12 +3,10 @@ import os
 from pathlib import Path
 
 import sqlite3
-import boto3
 import pytest
 from httpcore import Request, Response
-from moto import mock_s3
 
-from hishel import FileStorage, InMemoryStorage, RedisStorage, S3Storage, SQLiteStorage
+from hishel import FileStorage, InMemoryStorage, RedisStorage, SQLiteStorage
 from hishel._serializers import Metadata
 from hishel._utils import sleep, generate_key
 
@@ -25,50 +23,9 @@ def is_redis_down() -> bool:
         return True
 
 
-@pytest.fixture(scope="function")
-def aws_credentials():
-    """Mocked AWS Credentials for moto."""
-
-    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
-    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
-    os.environ["AWS_SECURITY_TOKEN"] = "testing"
-    os.environ["AWS_SESSION_TOKEN"] = "testing"
-    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
-
-
-@pytest.fixture(scope="function")
-def s3(aws_credentials):
-    with mock_s3():
-        yield boto3.client("s3", region_name="us-east-1")
-
-
 
 def test_filestorage(use_temp_dir):
     storage = FileStorage()
-
-    request = Request(b"GET", "https://example.com")
-
-    key = generate_key(request)
-
-    response = Response(200, headers=[], content=b"test")
-    response.read()
-
-    storage.store(key, response=response, request=request, metadata=dummy_metadata)
-
-    stored_data = storage.retrieve(key)
-    assert stored_data is not None
-    stored_response, stored_request, metadata = stored_data
-    stored_response.read()
-    assert isinstance(stored_response, Response)
-    assert stored_response.status == 200
-    assert stored_response.headers == []
-    assert stored_response.content == b"test"
-
-
-
-def test_s3storage(use_temp_dir, s3):
-    boto3.client("s3").create_bucket(Bucket="testBucket")
-    storage = S3Storage(bucket_name="testBucket")
 
     request = Request(b"GET", "https://example.com")
 
@@ -176,29 +133,6 @@ def test_filestorage_expired(use_temp_dir, anyio_backend):
     assert storage.retrieve(first_key) is not None
 
     sleep(0.3)
-    storage.store(second_key, response=response, request=second_request, metadata=dummy_metadata)
-
-    assert storage.retrieve(first_key) is None
-
-
-
-def test_s3storage_expired(use_temp_dir, s3, anyio_backend):
-    boto3.client("s3").create_bucket(Bucket="testBucket")
-    storage = S3Storage(bucket_name="testBucket", ttl=3)
-
-    first_request = Request(b"GET", "https://example.com")
-    second_request = Request(b"GET", "https://anotherexample.com")
-
-    first_key = generate_key(first_request)
-    second_key = generate_key(second_request)
-
-    response = Response(200, headers=[], content=b"test")
-    response.read()
-
-    storage.store(first_key, response=response, request=first_request, metadata=dummy_metadata)
-    assert storage.retrieve(first_key) is not None
-
-    sleep(3)
     storage.store(second_key, response=response, request=second_request, metadata=dummy_metadata)
 
     assert storage.retrieve(first_key) is None
@@ -316,42 +250,3 @@ def test_filestorage_empty_file_exception(use_temp_dir):
         file.truncate(0)
     assert os.path.getsize(filedir) == 0
     assert storage.retrieve(key) is None
-
-
-
-def test_s3storage_timer(use_temp_dir, s3):
-    boto3.client("s3").create_bucket(Bucket="testBucket")
-    storage = S3Storage(bucket_name="testBucket", ttl=5, check_ttl_every=5)
-
-    first_request = Request(b"GET", "https://example.com")
-    second_request = Request(b"GET", "https://anotherexample.com")
-
-    first_key = generate_key(first_request)
-    second_key = generate_key(second_request)
-
-    response = Response(200, headers=[], content=b"test")
-    response.read()
-
-    storage.store(first_key, response=response, request=first_request, metadata=dummy_metadata)
-    assert storage.retrieve(first_key) is not None
-    sleep(3)
-    assert storage.retrieve(first_key) is not None
-    storage.store(second_key, response=response, request=second_request, metadata=dummy_metadata)
-    assert storage.retrieve(second_key) is not None
-    sleep(2)
-    assert storage.retrieve(first_key) is None
-    assert storage.retrieve(second_key) is not None
-    sleep(3)
-    assert storage.retrieve(second_key) is None
-
-
-
-def test_s3storage_key_error(use_temp_dir, s3):
-    """Triggers `NoSuchKey` error."""
-
-    boto3.client("s3").create_bucket(Bucket="testBucket")
-    storage = S3Storage(bucket_name="testBucket", ttl=60)
-    first_request = Request(b"GET", "https://example.com")
-    first_key = generate_key(first_request)
-
-    assert storage.retrieve(first_key) is None


### PR DESCRIPTION
Now, cache hits cause the cache item to reset his ttl, which is not expected behavior for end users, and this PR corrects that.

Cache hits reset the ttl because they change the metadata of the cached response; to prevent this, I've implemented a new API for storages called _update_metadata_, which just updates the metadata without effecting the ttl.

Now:

```python
import hishel
from time import sleep


client = hishel.CacheClient(
    storage=hishel.InMemoryStorage(ttl=1)
)

resp = client.get("https://hishel.com")
print(resp.extensions["from_cache"]) # False

sleep(0.9)

resp = client.get("https://hishel.com")
print(resp.extensions["from_cache"]) # True

sleep(0.9)

resp = client.get("https://hishel.com")
print(resp.extensions["from_cache"]) # True

sleep(0.9)

resp = client.get("https://hishel.com")
print(resp.extensions["from_cache"]) # True
```

Expected

```python
import hishel
from time import sleep


client = hishel.CacheClient(
    storage=hishel.InMemoryStorage(ttl=1)
)

resp = client.get("https://hishel.com")
print(resp.extensions["from_cache"]) # False

sleep(0.9)

resp = client.get("https://hishel.com")
print(resp.extensions["from_cache"]) # True

sleep(0.9)

resp = client.get("https://hishel.com")
print(resp.extensions["from_cache"]) # False

sleep(0.9)

resp = client.get("https://hishel.com")
print(resp.extensions["from_cache"])  # True
```