### PR TITLE
Version 0.0.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unrelesed
+## 0.0.26 (12th April, 2024)
 
 - Expose `AsyncBaseStorage` and `BaseStorage`. (#220)
 - Prevent cache hits from resetting the ttl. (#215)

--- a/hishel/__init__.py
+++ b/hishel/__init__.py
@@ -14,4 +14,4 @@ def install_cache() -> None:  # pragma: no cover
     httpx.Client = CacheClient  # type: ignore
 
 
-__version__ = "0.0.25"
+__version__ = "0.0.26"


### PR DESCRIPTION
## 0.0.26 (12th April, 2024)

- Expose `AsyncBaseStorage` and `BaseStorage`. (#220)
- Prevent cache hits from resetting the ttl. (#215)
