### PR TITLE
fix(redis): do not update metadata with negative ttl

### DIFF
--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -424,7 +424,9 @@ class AsyncRedisStorage(AsyncBaseStorage):
 
         ttl_in_milliseconds = await self._client.pttl(key)
 
-        if ttl_in_milliseconds == -2:  # pragma: no cover
+        # -2: if the key does not exist in Redis
+        # -1: if the key exists in Redis but has no expiration
+        if ttl_in_milliseconds == -2 or ttl_in_milliseconds == -1:  # pragma: no cover
             await self.store(key, response, request, metadata)
         else:
             await self._client.set(

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -424,7 +424,9 @@ class RedisStorage(BaseStorage):
 
         ttl_in_milliseconds = self._client.pttl(key)
 
-        if ttl_in_milliseconds == -2:  # pragma: no cover
+        # -2: if the key does not exist in Redis
+        # -1: if the key exists in Redis but has no expiration
+        if ttl_in_milliseconds == -2 or ttl_in_milliseconds == -1:  # pragma: no cover
             self.store(key, response, request, metadata)
         else:
             self._client.set(

--- a/unasync.py
+++ b/unasync.py
@@ -43,7 +43,7 @@ SUBS = [
     ("__aenter__", "__enter__"),
     ("__aexit__", "__exit__"),
     ("*@pytest.mark.anyio", ""),
-    ('*@pytest.mark.parametrize\("anyio_backend", \["asyncio"\]\)', ""),
+    (r'*@pytest.mark.parametrize\("anyio_backend", \["asyncio"\]\)', ""),
     ("anysqlite", "sqlite3"),
 ]
 COMPILED_SUBS = [(re.compile(r"(^|\b)" + regex + r"($|\b)"), repl) for regex, repl in SUBS]


### PR DESCRIPTION
Hi! 

This attempts to fix the regression from #215 where `*RedisStorages` instantiated without a TTL will fail during `update_metadata()`.
The failure stems from PTTL returning `-1` if the key exists but does not have a TTL.

Improvements to this commit would involve E2E testing of hishel to prevent introducing similar regressions in the future.
I might suggest VCR-esque tests for each of the storages, but I haven't gone that far in this bugfix attempt.
