### PR TITLE
Version 0.0.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.27 (31th May, 2024)
+
+- Fix `RedisStorage` when using without ttl. (#231)
+
 ## 0.0.26 (12th April, 2024)
 
 - Expose `AsyncBaseStorage` and `BaseStorage`. (#220)

--- a/hishel/__init__.py
+++ b/hishel/__init__.py
@@ -14,4 +14,4 @@ def install_cache() -> None:  # pragma: no cover
     httpx.Client = CacheClient  # type: ignore
 
 
-__version__ = "0.0.26"
+__version__ = "0.0.27"


### PR DESCRIPTION
# Changelog

## 0.0.27 (31th May, 2024)

- Fix `RedisStorage` when using without ttl. (#231)
