### PR TITLE
Version 0.0.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## development
+## 0.0.28 (23th June, 2024)
 
 - Add `revalidated` response extension. (#242)
 

--- a/hishel/__init__.py
+++ b/hishel/__init__.py
@@ -14,4 +14,4 @@ def install_cache() -> None:  # pragma: no cover
     httpx.Client = CacheClient  # type: ignore
 
 
-__version__ = "0.0.27"
+__version__ = "0.0.28"


### PR DESCRIPTION
# Changelog

## 0.0.28 (23th June, 2024)

- Add `revalidated` response extension. (#242)
