### PR TITLE
Revalidation requests should pass through extensions from caller.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## development
 
 - Fix cache update on revalidation response with content (rfc9111 section 4.3.3) (#239)
+- Fix request extensions that were not passed into revalidation request for transport-based implementation (but were
+  passed for the pool-based impl) (#247).
 
 ## 0.0.29 (23th June, 2024)
 

--- a/hishel/_async/_transports.py
+++ b/hishel/_async/_transports.py
@@ -156,6 +156,7 @@ class AsyncCacheTransport(httpx.AsyncBaseTransport):
                     url=normalized_url(res.url),
                     headers=res.headers,
                     stream=AsyncCacheStream(res.stream),
+                    extensions=res.extensions,
                 )
                 try:
                     revalidation_response = await self._transport.handle_async_request(revalidation_request)

--- a/hishel/_sync/_transports.py
+++ b/hishel/_sync/_transports.py
@@ -156,6 +156,7 @@ class CacheTransport(httpx.BaseTransport):
                     url=normalized_url(res.url),
                     headers=res.headers,
                     stream=CacheStream(res.stream),
+                    extensions=res.extensions,
                 )
                 try:
                     revalidation_response = self._transport.handle_request(revalidation_request)

--- a/tests/_async/test_transport.py
+++ b/tests/_async/test_transport.py
@@ -1,4 +1,5 @@
 import typing as tp
+from unittest.mock import AsyncMock
 
 import httpx
 import pytest
@@ -373,3 +374,54 @@ async def test_revalidation_with_new_content():
             stored_response, stored_request, stored_metadata = stored
             assert extract_header_values_decoded(stored_response.headers, b"Date") == ["Mon, 25 Aug 2015 12:00:11 GMT"]
             assert stored_response.content == b"Eat at Joe's."
+
+
+@pytest.mark.anyio
+async def test_transport_revalidation_forward_extensions():
+    class MockedClock(BaseClock):
+        current = 1440504000  # Mon, 25 Aug 2015 12:00:00 GMT
+
+        def now(self) -> int:
+            return self.current
+
+    clock = MockedClock()
+    controller = hishel.Controller(clock=clock)
+
+    async with hishel.MockAsyncTransport() as transport:
+        transport.handle_async_request = AsyncMock(side_effect=transport.handle_async_request)  # type: ignore[method-assign]
+        transport.add_responses(
+            [
+                httpx.Response(
+                    200,
+                    headers=[
+                        (b"Cache-Control", b"max-age=1"),
+                        (b"Date", b"Mon, 25 Aug 2015 12:00:00 GMT"),
+                    ],
+                ),
+                httpx.Response(
+                    304,
+                    headers=[
+                        (b"Cache-Control", b"max-age=1"),
+                        (b"Date", b"Mon, 25 Aug 2015 12:00:01 GMT"),
+                    ],
+                ),
+            ]
+        )
+        async with hishel.AsyncCacheTransport(
+            transport=transport, controller=controller, storage=hishel.AsyncInMemoryStorage()
+        ) as cache_transport:
+            # first request with extensions
+            await cache_transport.handle_async_request(
+                httpx.Request("GET", "https://www.example.com", extensions={"foo": "bar"})
+            )
+            assert transport.handle_async_request.call_args[0][0].extensions["foo"] == "bar"
+
+            # cache expires
+            clock.current += 1
+
+            # second request with extensions that should be passed to revalidation request
+            response = await cache_transport.handle_async_request(
+                httpx.Request("GET", "https://www.example.com", extensions={"foo": "baz"})
+            )
+            assert response.extensions["revalidated"] is True
+            assert transport.handle_async_request.call_args[0][0].extensions["foo"] == "baz"

--- a/tests/_sync/test_pool.py
+++ b/tests/_sync/test_pool.py
@@ -1,4 +1,5 @@
 import typing as tp
+from unittest.mock import Mock
 
 import httpcore
 import pytest
@@ -344,3 +345,54 @@ def test_revalidation_with_new_content():
             stored_response, stored_request, stored_metadata = stored
             assert extract_header_values_decoded(stored_response.headers, b"Date") == ["Mon, 25 Aug 2015 12:00:11 GMT"]
             assert stored_response.content == b"Eat at Joe's."
+
+
+
+def test_transport_revalidation_forward_extensions():
+    class MockedClock(BaseClock):
+        current = 1440504000  # Mon, 25 Aug 2015 12:00:00 GMT
+
+        def now(self) -> int:
+            return self.current
+
+    clock = MockedClock()
+    controller = hishel.Controller(clock=clock)
+
+    with hishel.MockConnectionPool() as pool:
+        pool.handle_request = Mock(side_effect=pool.handle_request)  # type: ignore[method-assign]
+        pool.add_responses(
+            [
+                httpcore.Response(
+                    200,
+                    headers=[
+                        (b"Cache-Control", b"max-age=1"),
+                        (b"Date", b"Mon, 25 Aug 2015 12:00:00 GMT"),
+                    ],
+                ),
+                httpcore.Response(
+                    304,
+                    headers=[
+                        (b"Cache-Control", b"max-age=1"),
+                        (b"Date", b"Mon, 25 Aug 2015 12:00:01 GMT"),
+                    ],
+                ),
+            ]
+        )
+        with hishel.CacheConnectionPool(
+            pool=pool, controller=controller, storage=hishel.InMemoryStorage()
+        ) as cache_pool:
+            # first request with extensions
+            cache_pool.handle_request(
+                httpcore.Request("GET", "https://www.example.com", extensions={"foo": "bar"})
+            )
+            assert pool.handle_request.call_args[0][0].extensions["foo"] == "bar"
+
+            # cache expires
+            clock.current += 1
+
+            # second request with extensions that should be passed to revalidation request
+            response = cache_pool.handle_request(
+                httpcore.Request("GET", "https://www.example.com", extensions={"foo": "baz"})
+            )
+            assert response.extensions["revalidated"] is True
+            assert pool.handle_request.call_args[0][0].extensions["foo"] == "baz"

--- a/tests/_sync/test_transport.py
+++ b/tests/_sync/test_transport.py
@@ -1,4 +1,5 @@
 import typing as tp
+from unittest.mock import Mock
 
 import httpx
 import pytest
@@ -373,3 +374,54 @@ def test_revalidation_with_new_content():
             stored_response, stored_request, stored_metadata = stored
             assert extract_header_values_decoded(stored_response.headers, b"Date") == ["Mon, 25 Aug 2015 12:00:11 GMT"]
             assert stored_response.content == b"Eat at Joe's."
+
+
+
+def test_transport_revalidation_forward_extensions():
+    class MockedClock(BaseClock):
+        current = 1440504000  # Mon, 25 Aug 2015 12:00:00 GMT
+
+        def now(self) -> int:
+            return self.current
+
+    clock = MockedClock()
+    controller = hishel.Controller(clock=clock)
+
+    with hishel.MockTransport() as transport:
+        transport.handle_request = Mock(side_effect=transport.handle_request)  # type: ignore[method-assign]
+        transport.add_responses(
+            [
+                httpx.Response(
+                    200,
+                    headers=[
+                        (b"Cache-Control", b"max-age=1"),
+                        (b"Date", b"Mon, 25 Aug 2015 12:00:00 GMT"),
+                    ],
+                ),
+                httpx.Response(
+                    304,
+                    headers=[
+                        (b"Cache-Control", b"max-age=1"),
+                        (b"Date", b"Mon, 25 Aug 2015 12:00:01 GMT"),
+                    ],
+                ),
+            ]
+        )
+        with hishel.CacheTransport(
+            transport=transport, controller=controller, storage=hishel.InMemoryStorage()
+        ) as cache_transport:
+            # first request with extensions
+            cache_transport.handle_request(
+                httpx.Request("GET", "https://www.example.com", extensions={"foo": "bar"})
+            )
+            assert transport.handle_request.call_args[0][0].extensions["foo"] == "bar"
+
+            # cache expires
+            clock.current += 1
+
+            # second request with extensions that should be passed to revalidation request
+            response = cache_transport.handle_request(
+                httpx.Request("GET", "https://www.example.com", extensions={"foo": "baz"})
+            )
+            assert response.extensions["revalidated"] is True
+            assert transport.handle_request.call_args[0][0].extensions["foo"] == "baz"

--- a/unasync.py
+++ b/unasync.py
@@ -13,7 +13,6 @@ SUBS = [
     ("AsyncFileStorage", "FileStorage"),
     ("AsyncBaseStorage", "BaseStorage"),
     ("AsyncFileManager", "FileManager"),
-    ("AsyncMock", "Mock"),
     ("MockAsyncConnectionPool", "MockConnectionPool"),
     ("MockAsyncTransport", "MockTransport"),
     ("AsyncRedisStorage", "RedisStorage"),

--- a/unasync.py
+++ b/unasync.py
@@ -13,6 +13,7 @@ SUBS = [
     ("AsyncFileStorage", "FileStorage"),
     ("AsyncBaseStorage", "BaseStorage"),
     ("AsyncFileManager", "FileManager"),
+    ("AsyncMock", "Mock"),
     ("MockAsyncConnectionPool", "MockConnectionPool"),
     ("MockAsyncTransport", "MockTransport"),
     ("AsyncRedisStorage", "RedisStorage"),


### PR DESCRIPTION
Fixes #247 behaviour so that transport implementation behaves the same as pool implementation.

I used `unittest.mock.AsyncMock` and its sync counterpart to check that the extensions are actually passed to the decorated transport/pool, I know this is not an existing practice in the current codebase, please tell me if you have an alternative for this.