### PR TITLE
Document default ttl=None

### DIFF
--- a/docs/advanced/storages.md
+++ b/docs/advanced/storages.md
@@ -71,6 +71,8 @@ storage = hishel.FileStorage(ttl=3600)
 If you do this, `Hishel` will delete any stored responses whose ttl has expired.
 In this example, the stored responses were limited to 1 hour.
 
+The default `ttl` is `None`, which means that responses will be stored until the [controller](controllers.md) decides to remove them.
+
 #### Check ttl every
 
 In order to avoid excessive memory utilization, `Hishel` must periodically clean the old responses, or responses that are not being used and should be deleted from the cache.
@@ -178,6 +180,8 @@ storage = hishel.RedisStorage(ttl=3600)
 If you do this, `Hishel` will delete any stored responses whose ttl has expired.
 In this example, the stored responses were limited to 1 hour.
 
+The default `ttl` is `None`, which means that responses will be stored until the [controller](controllers.md) decides to remove them.
+
 ### :simple-sqlite: SQLite storage
 
 `Hishel` includes built-in [sqlite](https://www.sqlite.org/index.html) support, allowing you to store your responses in sqlite database.
@@ -233,6 +237,8 @@ storage = hishel.SQLiteStorage(ttl=3600)
 If you do this, `Hishel` will delete any stored responses whose ttl has expired.
 In this example, the stored responses were limited to 1 hour.
 
+The default `ttl` is `None`, which means that responses will be stored until the [controller](controllers.md) decides to remove them.
+
 
 ### :material-aws: AWS S3 storage
 
@@ -283,6 +289,8 @@ storage = hishel.S3Storage(ttl=3600)
 
 If you do this, `Hishel` will delete any stored responses whose ttl has expired.
 In this example, the stored responses were limited to 1 hour.
+
+The default `ttl` is `None`, which means that responses will be stored until the [controller](controllers.md) decides to remove them.
 
 #### Check ttl every
 


### PR DESCRIPTION
As mentioned in #202, I added a sentence to the docs that explains the storage default behavior of not deleting anything when `ttl=None`.

I was tempted to put it into the top section, since it’s the same for all storages, but I noticed that there were already some duplicated explanations of the `ttl`, so I just added it there everywhere.