### PR TITLE
Implement disabling of caching private responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,11 +68,11 @@
 - Add `cache_disabled` extension to temporarily disable the cache (#109)
 - Update `datetime.datetime.utcnow()` to `datetime.datetime.now(datetime.timezone.utc)` since `datetime.datetime.utcnow()` has been deprecated. (#111)
 
-## 0.0.17 (6th November, 2023) 
+## 0.0.17 (6th November, 2023)
 
 - Fix `Last-Modified` validation.
 
-## 0.0.16 (25th October, 2023) 
+## 0.0.16 (25th October, 2023)
 
 - Add `install_cache` function. (#95)
 - Add sqlite support. (#92)
@@ -92,19 +92,19 @@
 
 - Add metadata into the response extensions. (#56)
 
-## 0.0.11 (15th August, 2023) 
+## 0.0.11 (15th August, 2023)
 
 - Add support for request `cache-control` directives. (#42)
 - Drop httpcore dependency. (#40)
 - Support HTTP methods only if they are defined as cacheable. (#37)
 
-## 0.0.10 (7th August, 2023) 
+## 0.0.10 (7th August, 2023)
 
 - Add Response metadata. (#33)
 - Add API Reference documentation. (#30)
 - Use stale responses only if the client is disconnected. (#28)
 
-## 0.0.9 (1st August, 2023) 
+## 0.0.9 (1st August, 2023)
 
 - Expose Controller API. (#23)
 
@@ -123,7 +123,7 @@
 ## 0.0.6 (29th July, 2023)
 
 - Fix `Vary` header validation. (#8)
-- Dump original requests with the responses. (#7) 
+- Dump original requests with the responses. (#7)
 
 ## 0.0.5 (29th July, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix cache update on revalidation response with content (rfc9111 section 4.3.3) (#239)
 - Fix request extensions that were not passed into revalidation request for transport-based implementation (but were
   passed for the pool-based impl) (#247).
+- Add `cache_private` property to the controller to support acting as shared cache. (#224)
 
 ## 0.0.29 (23th June, 2024)
 

--- a/docs/advanced/controllers.md
+++ b/docs/advanced/controllers.md
@@ -90,6 +90,22 @@ client = hishel.CacheClient(controller=controller)
 !!! tip
     If you're not familiar with `Heuristics Caching`, you can [read about it in the specification](https://www.rfc-editor.org/rfc/rfc9111.html#name-calculating-heuristic-fresh).
 
+### Preventing caching of private responses
+
+If you want `Hishel` to act as a _shared_ cache, you need to prevent it from caching responses with the `private` directive.
+
+Example:
+
+```python
+import hishel
+
+controller = hishel.Controller(cache_private=False)
+client = hishel.CacheClient(controller=controller)
+```
+
+!!! note
+    Servers may prohibit only some headers from being stored in a shared cache by sending a headers such as `Cache-Control: private=set-cookie`. However, `Hishel` with `cache_private=False` will still not cache the response, at all.
+
 ### Allowing stale responses
 
 Some servers allow the use of stale responses if they cannot be re-validated or the client is disconnected from the server. Clients MAY use stale responses in such cases, but this behavior is disabled by default in `Hishel`.

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -160,6 +160,34 @@ def test_is_cachable_for_no_store():
     assert not controller.is_cachable(request=request, response=response)
 
 
+def test_is_cachable_for_shared_cache():
+    controller = Controller(cache_private=False, allow_heuristics=True)
+
+    request = Request(b"GET", b"https://example.com", headers=[])
+
+    response = Response(200, headers=[(b"Cache-Control", b"public")])
+
+    assert controller.is_cachable(request=request, response=response)
+
+    response = Response(200, headers=[(b"Cache-Control", b"private")])
+
+    assert not controller.is_cachable(request=request, response=response)
+
+    response = Response(200, headers=[(b"Cache-Control", b"private=set-cookie")])
+
+    assert not controller.is_cachable(request=request, response=response)
+
+
+def test_is_cachable_for_private_cache():
+    controller = Controller()
+
+    request = Request(b"GET", b"https://example.com", headers=[])
+
+    response = Response(200, headers=[(b"Cache-Control", b"private")])
+
+    assert controller.is_cachable(request=request, response=response)
+
+
 def test_get_freshness_lifetime():
     response = Response(status=200, headers=[(b"Cache-Control", b"max-age=3600")])
 


### PR DESCRIPTION
I implemented the simple disabling of caching private responses that was suggested in #224 in order to support creating a shared cache.

I didn't implement any special handling for the case where a server specifies that only some headers are supposed to be private. Instead, any response with `private` in the `Cache-Control` is considered not cacheable.

Closes #224.