### PR TITLE
Make file cache scanning more efficient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix request extensions that were not passed into revalidation request for transport-based implementation (but were
   passed for the pool-based impl) (#247).
 - Add `cache_private` property to the controller to support acting as shared cache. (#224)
+- Improve efficiency of scanning cached responses in `FileStorage` by reducing number of syscalls. (#252)
 
 ## 0.0.29 (23th June, 2024)
 

--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -203,11 +203,12 @@ class AsyncFileStorage(AsyncBaseStorage):
 
         self._last_cleaned = time.monotonic()
         async with self._lock:
-            for file in self._base_path.iterdir():
-                if file.is_file():
-                    age = time.time() - file.stat().st_mtime
-                    if age > self._ttl:
-                        file.unlink()
+            with os.scandir(self._base_path) as entries:
+                for entry in entries:
+                    if entry.is_file():
+                        age = time.time() - entry.stat().st_mtime
+                        if age > self._ttl:
+                            os.unlink(entry.path)
 
 
 class AsyncSQLiteStorage(AsyncBaseStorage):

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -203,11 +203,12 @@ class FileStorage(BaseStorage):
 
         self._last_cleaned = time.monotonic()
         with self._lock:
-            for file in self._base_path.iterdir():
-                if file.is_file():
-                    age = time.time() - file.stat().st_mtime
-                    if age > self._ttl:
-                        file.unlink()
+            with os.scandir(self._base_path) as entries:
+                for entry in entries:
+                    if entry.is_file():
+                        age = time.time() - entry.stat().st_mtime
+                        if age > self._ttl:
+                            os.unlink(entry.path)
 
 
 class SQLiteStorage(BaseStorage):


### PR DESCRIPTION
By using `os.scandir`, we can save the syscall for `is_file`.

Closes #252.