### PR TITLE
Version 0.0.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## development
+## 0.0.30 (12th July, 2024)
 
 - Fix cache update on revalidation response with content (rfc9111 section 4.3.3) (#239)
 - Fix request extensions that were not passed into revalidation request for transport-based implementation (but were

--- a/hishel/__init__.py
+++ b/hishel/__init__.py
@@ -14,4 +14,4 @@ def install_cache() -> None:  # pragma: no cover
     httpx.Client = CacheClient  # type: ignore
 
 
-__version__ = "0.0.29"
+__version__ = "0.0.30"


### PR DESCRIPTION
# Changelog

## 0.0.30 (12th July, 2024)

- Fix cache update on revalidation response with content (rfc9111 section 4.3.3) (#239)
- Fix request extensions that were not passed into revalidation request for transport-based implementation (but were
  passed for the pool-based impl) (#247).
- Add `cache_private` property to the controller to support acting as shared cache. (#224)
- Improve efficiency of scanning cached responses in `FileStorage` by reducing number of syscalls. (#252)
- Add `remove` support for storages (#241)
