### PR TITLE
Ignoring error when cleaning cache to not raise Exception on race conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## development
+
+- Fix race condition on file storage cache clean.
+
 ## 0.0.30 (12th July, 2024)
 
 - Fix cache update on revalidation response with content (rfc9111 section 4.3.3) (#239)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## development
 
-- Fix race condition on file storage cache clean.
+- Ignore file not found error when cleaning up a file storage. (#264)  
 
 ## 0.0.30 (12th July, 2024)
 

--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -227,10 +227,13 @@ class AsyncFileStorage(AsyncBaseStorage):
         async with self._lock:
             with os.scandir(self._base_path) as entries:
                 for entry in entries:
-                    if entry.is_file():
-                        age = time.time() - entry.stat().st_mtime
-                        if age > self._ttl:
-                            os.unlink(entry.path)
+                    try:
+                        if entry.is_file():
+                            age = time.time() - entry.stat().st_mtime
+                            if age > self._ttl:
+                                os.unlink(entry.path)
+                    except FileNotFoundError:  # pragma: no cover
+                        pass
 
 
 class AsyncSQLiteStorage(AsyncBaseStorage):

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -227,10 +227,13 @@ class FileStorage(BaseStorage):
         with self._lock:
             with os.scandir(self._base_path) as entries:
                 for entry in entries:
-                    if entry.is_file():
-                        age = time.time() - entry.stat().st_mtime
-                        if age > self._ttl:
-                            os.unlink(entry.path)
+                    try:
+                        if entry.is_file():
+                            age = time.time() - entry.stat().st_mtime
+                            if age > self._ttl:
+                                os.unlink(entry.path)
+                    except FileNotFoundError:  # pragma: no cover
+                        pass
 
 
 class SQLiteStorage(BaseStorage):


### PR DESCRIPTION
I have multiple python processes that use the same file storage cache, But sometimes there is a race condition when they try to clean the cache at the same time.
So I just added a try block to ignore the exception when removing a file if the file is not found.