### PR TITLE
Remove direct dependency on typing_extensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ classifiers = [
 ]
 dependencies = [
     "httpx>=0.22.0",
-    "typing_extensions>=4.8.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Since all calls to `typing_extensions` are behind `typing.TYPE_CHECKING`, there is no need for a direct dependency on it; it's provided by type checkers.