### PR TITLE
blake2b not fips compliant

### DIFF
--- a/hishel/_utils.py
+++ b/hishel/_utils.py
@@ -49,7 +49,7 @@ def generate_key(request: httpcore.Request, body: bytes = b"") -> str:
 
     key_parts = [request.method, encoded_url, body]
 
-    key = blake2b(digest_size=16)
+    key = blake2b(digest_size=16, usedforsecurity=False)
     for part in key_parts:
         key.update(part)
     return key.hexdigest()


### PR DESCRIPTION
blake2b is not fips compliant, but since it is only used for caching here, can be allowed with usedforsecurity=False. See #284.