### PR TITLE
Use SyncByteStream instead of ByteStream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## development
 
 - Fix compatibility with httpx. (#291)
+- Use `SyncByteStream` instead of `ByteStream`. (#298)
 
 ## 0.1.1 (2nd Nov, 2024)
 

--- a/hishel/_sync/_transports.py
+++ b/hishel/_sync/_transports.py
@@ -5,7 +5,7 @@ import typing as tp
 
 import httpcore
 import httpx
-from httpx import ByteStream, Request, Response
+from httpx import SyncByteStream, Request, Response
 from httpx._exceptions import ConnectError
 
 from hishel._utils import extract_header_values_decoded, normalized_url
@@ -29,7 +29,7 @@ def generate_504() -> Response:
     return Response(status_code=504)
 
 
-class CacheStream(ByteStream):
+class CacheStream(SyncByteStream):
     def __init__(self, httpcore_stream: tp.Iterable[bytes]):
         self._httpcore_stream = httpcore_stream
 

--- a/unasync.py
+++ b/unasync.py
@@ -27,7 +27,7 @@ SUBS = [
     ("AsyncClient", "Client"),
     ("AsyncIterable", "Iterable"),
     ("AsyncCacheStream", "CacheStream"),
-    ("AsyncByteStream", "ByteStream"),
+    ("AsyncByteStream", "SyncByteStream"),
     ("AsyncCacheConnectionPool", "CacheConnectionPool"),
     ("handle_async_request", "handle_request"),
     ("aread", "read"),


### PR DESCRIPTION
The synchronous version of `AsyncByteStream` is actually `SyncByteStream`, not `ByteStream`:

```python
class ByteStream(AsyncByteStream, SyncByteStream):
    def __init__(self, stream: bytes) -> None:
        ...

    def __iter__(self) -> Iterator[bytes]:
        ...

    async def __aiter__(self) -> AsyncIterator[bytes]:
        ...
```

```python
class SyncByteStream:
    def __iter__(self) -> Iterator[bytes]:
        ...

    def close(self) -> None:
        ...
```