### PR TITLE
add ignore_response_cache_control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix compatibility with httpx. (#291)
 - Use `SyncByteStream` instead of `ByteStream`. (#298)
+- Add `ignore_response_cache_control` (default `False`) as controller argument
 
 ## 0.1.1 (2nd Nov, 2024)
 


### PR DESCRIPTION
Fixes #301.

Maybe `force_cache` should be removed. It seems to serve the same purpose (according to the docs), but `ignore_response_cache_control` leaves better control to the user.