### PR TITLE
use pre-commit for linting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,16 @@ on:
     branches: ["master"]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1
+
   tests:
+    needs: [lint]
     name: "Python ${{ matrix.python-version }}"
     runs-on: "ubuntu-latest"
     

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,5 +8,4 @@ repos:
     rev: v1.14.1
     hooks:
       - id: mypy
-        files: src
         args: ["--install-types", "--non-interactive"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.9.2
+    hooks:
+      - id: ruff
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.14.1
+    hooks:
+      - id: mypy
+        files: src
+        args: ["--install-types", "--non-interactive"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,5 @@
 -e .[yaml,redis,sqlite,s3]
 
-# linting
-ruff==0.6.3
-mypy==1.14.1
-
 # docs
 mkdocs==1.6.1
 mkdocs-material==9.5.1

--- a/scripts/check
+++ b/scripts/check
@@ -4,9 +4,5 @@ export PREFIX=""
 if [ -d '.venv' ] ; then
     export PREFIX=".venv/bin/"
 fi
-export SOURCE_FILES="hishel tests"
 
-${PREFIX}ruff format $SOURCE_FILES --diff
-${PREFIX}ruff check $SOURCE_FILES
-${PREFIX}mypy $SOURCE_FILES
 ${PREFIX}python unasync.py --check


### PR DESCRIPTION
Lints at every commit, locally. Can be skipped with
```
git commit -a --no-verify
```
Can be run manually with
```
pre-commit run --all
```