### PR TITLE
Don't raise exceptions if date-containing headers are invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix compatibility with httpx. (#291)
 - Use `SyncByteStream` instead of `ByteStream`. (#298)
+- Don't raise exceptions if date-containing headers are invalid. (#318)
 
 ## 0.1.1 (2nd Nov, 2024)
 

--- a/hishel/_utils.py
+++ b/hishel/_utils.py
@@ -82,9 +82,11 @@ def header_presents(headers: tp.List[tp.Tuple[bytes, bytes]], header_key: bytes)
     return bool(extract_header_values(headers, header_key, single=True))
 
 
-def parse_date(date: str) -> int:
+def parse_date(date: str) -> tp.Optional[int]:
     expires = parsedate_tz(date)
-    timestamp = calendar.timegm(expires[:6])  # type: ignore
+    if expires is None:
+        return None
+    timestamp = calendar.timegm(expires[:6])
     return timestamp
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -89,6 +89,12 @@ def test_parse_date():
     assert timestamp == 1440504000
 
 
+def test_parse_invalid_date():
+    date = "0"
+    timestamp = parse_date(date)
+    assert timestamp is None
+
+
 def test_float_seconds_to_milliseconds():
     seconds = 1.234
     milliseconds = float_seconds_to_int_milliseconds(seconds)


### PR DESCRIPTION
`hishel._utils.parse_date()` uses `email.utils.parsedate_tz()` but wasn't checking for it returning `None`.

I hit this running another package's pytest tests, one of which fires up HTTP servers on localhost to test what its API requests send over the wire.  I've run those tests hundreds of times, but for some reason the test HTTP server **once** sent an invalid "expires" header and made a test fail. I don't know why, and I didn't find anything obvious in the cache, but anyway, this PR ought to make it never happen again by making Hishel handle headers containing invalid dates by doing whatever it would've done if the header hadn't been there at all.

```
.venv/lib/python3.10/site-packages/httpx/_client.py:1014: in _send_single_request
    response = transport.handle_request(request)
.venv/lib/python3.10/site-packages/hishel/_sync/_transports.py:131: in handle_request
    res = self._controller.construct_response_from_cache(
.venv/lib/python3.10/site-packages/hishel/_controller.py:443: in construct_response_from_cache
    freshness_lifetime = get_freshness_lifetime(response)
.venv/lib/python3.10/site-packages/hishel/_controller.py:62: in get_freshness_lifetime
    expires_timestamp = parse_date(expires)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

date = '0'

    def parse_date(date: str) -> int:
        expires = parsedate_tz(date)
>       timestamp = calendar.timegm(expires[:6])  # type: ignore
E       TypeError: 'NoneType' object is not subscriptable

.venv/lib/python3.10/site-packages/hishel/_utils.py:87: TypeError
```