### PR TITLE
Avoid race condition whenever unlinking cache in FileStorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## development
+
+- Avoid race condition when unlinking files in `FileStorage`. (#334)  
+
 ## 0.1.2 (5th April, 2025)
 
 - Add check for fips compliant python. (#325)

--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -159,7 +159,7 @@ class AsyncFileStorage(AsyncBaseStorage):
 
         async with self._lock:
             if response_path.exists():
-                response_path.unlink()
+                response_path.unlink(missing_ok=True)
 
     async def update_metadata(self, key: str, response: Response, request: Request, metadata: Metadata) -> None:
         """
@@ -222,7 +222,7 @@ class AsyncFileStorage(AsyncBaseStorage):
             if response_path.is_file():
                 age = time.time() - response_path.stat().st_mtime
                 if age > self._ttl:
-                    response_path.unlink()
+                    response_path.unlink(missing_ok=True)
             return
 
         self._last_cleaned = time.monotonic()

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -159,7 +159,7 @@ class FileStorage(BaseStorage):
 
         with self._lock:
             if response_path.exists():
-                response_path.unlink()
+                response_path.unlink(missing_ok=True)
 
     def update_metadata(self, key: str, response: Response, request: Request, metadata: Metadata) -> None:
         """
@@ -222,7 +222,7 @@ class FileStorage(BaseStorage):
             if response_path.is_file():
                 age = time.time() - response_path.stat().st_mtime
                 if age > self._ttl:
-                    response_path.unlink()
+                    response_path.unlink(missing_ok=True)
             return
 
         self._last_cleaned = time.monotonic()


### PR DESCRIPTION
Previously, concurrent threads could hit race conditions when unlinking files and hit `FileNotFoundError`s

See https://github.com/karpetrosyan/hishel/pull/264 for a similar previous PR