### PR TITLE
Bump redis to 6.0.0 and related fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## development
 
+- Remove `types-redis` from dev dependencies (#336)
+- Bump redis to 6.0.0 and address async `.close()` deprecation warning (#336)
 - Avoid race condition when unlinking files in `FileStorage`. (#334)  
 
 ## 0.1.2 (5th April, 2025)

--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -507,7 +507,7 @@ class AsyncRedisStorage(AsyncBaseStorage):
         return self._serializer.loads(cached_response)
 
     async def aclose(self) -> None:  # pragma: no cover
-        await self._client.close()
+        await self._client.aclose()
 
 
 class AsyncInMemoryStorage(AsyncBaseStorage):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ yaml = [
 ]
 
 redis = [
-    "redis==5.0.4"
+    "redis==6.0.0"
 ]
 
 sqlite = [
@@ -92,7 +92,7 @@ filterwarnings = []
 
 [tool.coverage.run]
 omit = [
-    "venv/*", 
+    "venv/*",
     "hishel/_sync/*",
     "hishel/_s3.py"
 ]
@@ -136,6 +136,5 @@ dev = [
     "trio==0.28.0",
     "types-boto3==1.0.2",
     "types-pyyaml==6.0.12.20240311",
-    "types-redis==4.6.0.20240425",
     "zipp>=3.19.1",
 ]


### PR DESCRIPTION
This contains a variety of fixes around Redis:

* Bump Redis to 6.0.0.
* Remove `types-redis` as no longer required for `redis>5.0.0`.
* Fixed DeprecationWarning to use `.aclose()` on async client.

```terminal
  /opt/homebrew/Caskroom/mambaforge/base/envs/my-env/lib/python3.11/site-packages/hishel/_async/_storages.py:510: DeprecationWarning: Call to deprecated close. (Use aclose() instead) -- Deprecated since version 5.0.1.
    await self._client.close()
```

>[!NOTE]
> Instead of updating direct to `v6.0.0`, `v5.3.0` was also previously released around the same time. However there were a couple `mypy` errors that were resolved in `v6.0.0`. This could be changed if you prefer.
>
> In `v6.0.0` the most relevant change seems to be that clients now have a default retry strategy: https://github.com/redis/redis-py/releases/tag/v6.0.0