### PR TITLE
Add type hints to HishelClient constructor for improved clarity

### DIFF
--- a/hishel/_async/_client.py
+++ b/hishel/_async/_client.py
@@ -2,15 +2,23 @@ import typing as tp
 
 import httpx
 
+from hishel._async._storages import AsyncBaseStorage
 from hishel._async._transports import AsyncCacheTransport
+from hishel._controller import Controller
 
 __all__ = ("AsyncCacheClient",)
 
 
 class AsyncCacheClient(httpx.AsyncClient):
-    def __init__(self, *args: tp.Any, **kwargs: tp.Any):
-        self._storage = kwargs.pop("storage") if "storage" in kwargs else None
-        self._controller = kwargs.pop("controller") if "controller" in kwargs else None
+    def __init__(
+        self,
+        *args: tp.Any,
+        storage: tp.Optional[AsyncBaseStorage] = None,
+        contoller: tp.Optional[Controller] = None,
+        **kwargs: tp.Any,
+    ):
+        self._storage = storage
+        self._controller = contoller
         super().__init__(*args, **kwargs)
 
     def _init_transport(self, *args, **kwargs) -> AsyncCacheTransport:  # type: ignore

--- a/hishel/_sync/_client.py
+++ b/hishel/_sync/_client.py
@@ -2,15 +2,23 @@ import typing as tp
 
 import httpx
 
+from hishel._sync._storages import BaseStorage
 from hishel._sync._transports import CacheTransport
+from hishel._controller import Controller
 
 __all__ = ("CacheClient",)
 
 
 class CacheClient(httpx.Client):
-    def __init__(self, *args: tp.Any, **kwargs: tp.Any):
-        self._storage = kwargs.pop("storage") if "storage" in kwargs else None
-        self._controller = kwargs.pop("controller") if "controller" in kwargs else None
+    def __init__(
+        self,
+        *args: tp.Any,
+        storage: tp.Optional[BaseStorage] = None,
+        contoller: tp.Optional[Controller] = None,
+        **kwargs: tp.Any,
+    ):
+        self._storage = storage
+        self._controller = contoller
         super().__init__(*args, **kwargs)
 
     def _init_transport(self, *args, **kwargs) -> CacheTransport:  # type: ignore

--- a/unasync.py
+++ b/unasync.py
@@ -39,6 +39,7 @@ SUBS = [
         "from httpcore._sync.interfaces import RequestInterface",
     ),
     ("from hishel._async._transports", "from hishel._sync._transports"),
+    ("from hishel._async._storages", "from hishel._sync._storages"),
     ("AsyncRequestInterface", "RequestInterface"),
     ("__aenter__", "__enter__"),
     ("__aexit__", "__exit__"),


### PR DESCRIPTION
This PR adds type hints to the HishelClient constructor to improve readability and developer experience. It helps clarify what arguments the client accepts without digging into the source.
No logic was changed, and compatibility with httpx.Client and httpx.AsyncClient is fully preserved as described in the docs.