### PR TITLE
Version 0.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,6 @@ classifiers = [
 ]
 dependencies = [
     "httpx>=0.28.0",
-    "httpx-aiohttp>=0.1.6",
-    "openai",
-    "requests>=2.32.3",
 ]
 
 [project.optional-dependencies]
@@ -120,18 +117,11 @@ select = [
     "E",
     "F",
     "W",
-    "I",
-    "TID251"
+    "I"
 ]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true
-
-[tool.ruff.lint.flake8-tidy-imports.banned-api]
-"hishel".msg = "The cgi module is deprecated, see https://peps.python.org/pep-0594/#cgi."
-
-[tool.uv.sources]
-openai = { git = "ssh://git@github.com/stainless-sdks/openai-python", branch = "stl-preview-head/robert/sdk-1337-customer-feature-request-python-support-for-httpx" }
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
# Changelog

## 0.1.3 (1st July, 2025)

- Remove `types-redis` from dev dependencies (#336)
- Bump redis to 6.0.0 and address async `.close()` deprecation warning (#336)
- Avoid race condition when unlinking files in `FileStorage`. (#334)
- Allow prodiving a `path_prefix` in `S3Storage` and `AsyncS3Storage`. (#342)
