### PR TITLE
Optimize request side max-age and max-stale treatment

### DIFF
--- a/hishel/_controller.py
+++ b/hishel/_controller.py
@@ -509,10 +509,11 @@ class Controller:
                 logger.debug(
                     (
                         f"Considering the resource located at {get_safe_url(request.url)} "
-                        "as invalid for cache use since the freshness lifetime has been exceeded more than max-stale."
+                        "as needing revalidation since the freshness lifetime has been exceeded more than max-stale."
                     )
                 )
-                return None
+                self._make_request_conditional(request=request, response=response)
+                return request
             else:
                 logger.debug(
                     (
@@ -532,10 +533,11 @@ class Controller:
                 logger.debug(
                     (
                         f"Considering the resource located at {get_safe_url(request.url)} "
-                        "as invalid for cache use since the age of the response exceeds the max-age directive."
+                        "as needing revalidation since the age of the response exceeds the max-age directive."
                     )
                 )
-                return None
+                self._make_request_conditional(request=request, response=response)
+                return request
 
         # the stored response is one of the following:
         #   fresh (see Section 4.2), or


### PR DESCRIPTION
According to RFC9111 5.2.1.1. max-age and 5.2.1.2. max-stale a client prefers an updated response from server instead of locally cached possibly stale one.

Those sections don't say anything about how such response is to be created.

This PR therefore proposes to optimize bandwidth usage by sending re-validation requests if max-age or max-stale are exceeded instead of enforcing a full re-download of a possibly still up-to-date local response object.

The final result is the same - a validated up-to-date response - just with a chance to save some bandwidth in case of 304 response.

Notes:

1) Browsers sometimes use `max-age=0` to enforce full re-downloads, but that's
   probably redundant due to `no-cache` directive handling this.

2) This is how httpx_caching handles those requests, which I find smarter
   than just enforcing full re-download.