### PR TITLE
Don't bomb if directory creation races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## development
+
+- Fix race condition in FileStorage initialization. (#353)
+
 ## 0.1.3 (1st July, 2025)
 
 - Remove `types-redis` from dev dependencies (#336)

--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -103,8 +103,7 @@ class AsyncFileStorage(AsyncBaseStorage):
         self._base_path = Path(base_path) if base_path is not None else Path(".cache/hishel")
         self._gitignore_file = self._base_path / ".gitignore"
 
-        if not self._base_path.is_dir():
-            self._base_path.mkdir(parents=True)
+        self._base_path.mkdir(parents=True, exist_ok=True)
 
         if not self._gitignore_file.is_file():
             with open(self._gitignore_file, "w", encoding="utf-8") as f:

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -103,8 +103,7 @@ class FileStorage(BaseStorage):
         self._base_path = Path(base_path) if base_path is not None else Path(".cache/hishel")
         self._gitignore_file = self._base_path / ".gitignore"
 
-        if not self._base_path.is_dir():
-            self._base_path.mkdir(parents=True)
+        self._base_path.mkdir(parents=True, exist_ok=True)
 
         if not self._gitignore_file.is_file():
             with open(self._gitignore_file, "w", encoding="utf-8") as f:


### PR DESCRIPTION
Fixes #352 

Use `mkdir(..., exist_ok=True)` instead of `if not is_dir(): mkdir()`, so that if multiple Hishel instances initialize at the same time, they don't collide and bomb.