### PR TITLE
JSONByteSerializer: A faster but stdlib-only serializer

### DIFF
--- a/hishel/_serializers.py
+++ b/hishel/_serializers.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 from httpcore import Request, Response
 
-from ._utils import normalized_url
+from hishel._utils import normalized_url
 
 try:
     import yaml
@@ -17,7 +17,7 @@ HEADERS_ENCODING = "iso-8859-1"
 KNOWN_RESPONSE_EXTENSIONS = ("http_version", "reason_phrase")
 KNOWN_REQUEST_EXTENSIONS = ("timeout", "sni_hostname")
 
-__all__ = ("PickleSerializer", "JSONSerializer", "YAMLSerializer", "BaseSerializer", "clone_model")
+__all__ = ("PickleSerializer", "JSONSerializer", "YAMLSerializer", "BaseSerializer", "JSONByteSerializer", "clone_model")
 
 T = tp.TypeVar("T", Request, Response)
 
@@ -327,3 +327,114 @@ class YAMLSerializer(BaseSerializer):
     @property
     def is_binary(self) -> bool:  # pragma: no cover
         return False
+
+
+class JSONByteSerializer(BaseSerializer):
+    """JSONFasterSerializer stores HTTP metadata as compact UTF-8 JSON followed by raw binary body bytes,
+    separated by a single null byte. This avoids base64 encoding, significantly reducing size and
+    improving performance for large responses.."""
+
+    def dumps(self, response: Response, request: Request, metadata: Metadata) -> tp.Union[str, bytes]:
+        """
+        Dumps the HTTP response and its HTTP request.
+
+        :param response: An HTTP response
+        :type response: Response
+        :param request: An HTTP request
+        :type request: Request
+        :param metadata: Additional information about the stored response
+        :type metadata: Metadata
+        :return: Serialized response
+        :rtype: tp.Union[str, bytes]
+        """
+        response_dict = {
+            "status": response.status,
+            "headers": [
+                (key.decode(HEADERS_ENCODING), value.decode(HEADERS_ENCODING)) for key, value in response.headers
+            ],
+            "extensions": {
+                key: value.decode("ascii")
+                for key, value in response.extensions.items()
+                if key in KNOWN_RESPONSE_EXTENSIONS
+            },
+        }
+
+        request_dict = {
+            "method": request.method.decode("ascii"),
+            "url": normalized_url(request.url),
+            "headers": [
+                (key.decode(HEADERS_ENCODING), value.decode(HEADERS_ENCODING)) for key, value in request.headers
+            ],
+            "extensions": {key: value for key, value in request.extensions.items() if key in KNOWN_REQUEST_EXTENSIONS},
+        }
+
+        metadata_dict = {
+            "cache_key": metadata["cache_key"],
+            "number_of_uses": metadata["number_of_uses"],
+            "created_at": metadata["created_at"].strftime("%a, %d %b %Y %H:%M:%S GMT"),
+        }
+
+        full_json = {
+            "response": response_dict,
+            "request": request_dict,
+            "metadata": metadata_dict,
+        }
+
+        return  json.dumps(full_json, separators=(",", ":")).encode("utf-8") + b"\0" + response.content
+
+    def loads(self, data: tp.Union[str, bytes]) -> tp.Tuple[Response, Request, Metadata]:
+        """
+        Loads the HTTP response and its HTTP request from serialized data.
+
+        :param data: Serialized data
+        :type data: tp.Union[str, bytes]
+        :return: HTTP response and its HTTP request
+        :rtype: tp.Tuple[Response, Request, Metadata]
+        """
+
+        full_json, body = data.split(b"\0", 1)
+        full_json = json.loads(full_json.decode("utf-8"))
+        response_dict = full_json["response"]
+        request_dict = full_json["request"]
+        metadata_dict = full_json["metadata"]
+        metadata_dict["created_at"] = datetime.strptime(
+            metadata_dict["created_at"],
+            "%a, %d %b %Y %H:%M:%S GMT",
+        )
+
+        response = Response(
+            status=response_dict["status"],
+            headers=[
+                (key.encode(HEADERS_ENCODING), value.encode(HEADERS_ENCODING))
+                for key, value in response_dict["headers"]
+            ],
+            content=body,
+            extensions={
+                key: value.encode("ascii")
+                for key, value in response_dict["extensions"].items()
+                if key in KNOWN_RESPONSE_EXTENSIONS
+            },
+        )
+
+        request = Request(
+            method=request_dict["method"],
+            url=request_dict["url"],
+            headers=[
+                (key.encode(HEADERS_ENCODING), value.encode(HEADERS_ENCODING)) for key, value in request_dict["headers"]
+            ],
+            extensions={
+                key: value for key, value in request_dict["extensions"].items() if key in KNOWN_REQUEST_EXTENSIONS
+            },
+        )
+
+        metadata = Metadata(
+            cache_key=metadata_dict["cache_key"],
+            created_at=metadata_dict["created_at"],
+            number_of_uses=metadata_dict["number_of_uses"],
+        )
+
+        return response, request, metadata
+
+    @property
+    def is_binary(self) -> bool:
+        return True

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,14 +1,10 @@
 import datetime
+import json
 
 import pytest
 from httpcore import Request, Response
 
-from hishel._serializers import (
-    JSONSerializer,
-    Metadata,
-    PickleSerializer,
-    YAMLSerializer,
-)
+from hishel._serializers import JSONByteSerializer, JSONSerializer, Metadata, PickleSerializer, YAMLSerializer
 from hishel._utils import normalized_url
 
 try:
@@ -288,6 +284,82 @@ def test_yaml_serializer_loads():
     )
 
     response, request, metadata = YAMLSerializer().loads(raw_response)
+    response.read()
+    assert response.status == 200
+    assert response.headers == [
+        (b"Content-Type", b"application/json"),
+        (b"Transfer-Encoding", b"chunked"),
+    ]
+    assert response.content == b"test"
+    assert response.extensions == {"http_version": b"HTTP/1.1", "reason_phrase": b"OK"}
+
+    assert request.method == b"GET"
+    assert normalized_url(request.url) == "https://example.com/"
+    assert request.headers == [(b"Accept-Encoding", b"gzip")]
+    assert request.extensions == {"sni_hostname": "example.com"}
+
+    assert metadata["cache_key"] == "test"
+    assert metadata["number_of_uses"] == 0
+    assert metadata["created_at"] == datetime.datetime(year=2003, month=8, day=25, hour=12)
+
+
+def test_jsonbyte_serializer_dumps():
+    request = Request(
+        method="GET",
+        url="https://example.com",
+        headers=[(b"Accept-Encoding", b"gzip")],
+        extensions={"sni_hostname": "example.com"},
+    )
+    response = Response(
+        status=200,
+        headers=[
+            (b"Content-Type", b"application/json"),
+            (b"Transfer-Encoding", b"chunked"),
+        ],
+        content=b"test",
+        extensions={"reason_phrase": b"OK", "http_version": b"HTTP/1.1"},
+    )
+    response.read()
+
+    metadata = Metadata(
+        cache_key="test",
+        number_of_uses=0,
+        created_at=datetime.datetime(year=2003, month=8, day=25, hour=12),
+    )
+
+    full = JSONByteSerializer().dumps(response=response, request=request, metadata=metadata)
+    meta_raw, body = full.split(b"\0", 1)
+    meta = json.loads(meta_raw.decode("utf-8"))
+
+    assert body == b"test"
+    assert (
+        meta["response"]["status"] == 200
+        and meta["request"]["method"] == "GET"
+        and meta["request"]["url"] == "https://example.com/"
+    )
+    assert meta["response"]["headers"] == [["Content-Type", "application/json"], ["Transfer-Encoding", "chunked"]]
+    assert meta["metadata"]["created_at"] == "Mon, 25 Aug 2003 12:00:00 GMT"
+
+
+def test_jsonbyte_serializer_loads():
+    meta = {
+        "response": {
+            "status": 200,
+            "headers": [["Content-Type", "application/json"], ["Transfer-Encoding", "chunked"]],
+            "extensions": {"reason_phrase": "OK", "http_version": "HTTP/1.1"},
+        },
+        "request": {
+            "method": "GET",
+            "url": "https://example.com/",
+            "headers": [["Accept-Encoding", "gzip"]],
+            "extensions": {"sni_hostname": "example.com"},
+        },
+        "metadata": {"cache_key": "test", "number_of_uses": 0, "created_at": "Mon, 25 Aug 2003 12:00:00 GMT"},
+    }
+
+    raw_response = json.dumps(meta, separators=(",", ":")).encode("utf-8") + b"\0" + b"test"
+    response, request, metadata = JSONByteSerializer().loads(raw_response)
+
     response.read()
     assert response.status == 200
     assert response.headers == [


### PR DESCRIPTION
### Background
As is mentioned in other issues, Hishel's default serializer is slow. There's a few ideas on how to improve this, ranging from databases to msgpack. Most of these involve longer dependency chains and various extensions.

The root cause really comes down to the serialization of large binary data. 
https://github.com/karpetrosyan/hishel/blob/b85f07e9f33c1e2ba6de6d620f1b3d54bb8d25d5/hishel/_serializers.py#L120
and 
https://github.com/karpetrosyan/hishel/blob/b85f07e9f33c1e2ba6de6d620f1b3d54bb8d25d5/hishel/_serializers.py#L177

### JSONByteSerializer 
This PR introduces a variant of the JSONSerializer: JSONByteSerializer.

It stores data as a JSON block, a null byte, and the binary data: `json.dumps(full_json, separators=(",", ":")).encode("utf-8") + b"\0" + response.content`.

It is *much* faster than JSONSerializer, uses only Python stdlib, results in ~25% smaller file sizes, etc. 

The downsides are that it is a customer binary format with no built-in versioning or checksum and assumes null byte never in metadata, although the last assumption is fair since the null byte is not legal JSON. 

### Test Results
[edgar_large_file.txt](https://github.com/user-attachments/files/21694180/edgar_large_file.txt)

Downloading a [1.5GB file ](https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip) from the SEC is *slower* with Hishel, not faster. Even a cache hit is extremely slow. 


| Test  | Serializer | Duration (sec) |  Size |
| ------------- | ---------- | ------------- | -------- |
| httpx.Client  | N/A | 14.96  |
| hishel.CacheClient - Cold | JSONSerializer - Default | 27.28  |  1.96GB | 
| hishel.CacheClient - Warm | JSONSerializer - Default | 18.78  |  
| hishel.CacheClient - Cold | JSONByteSerializer | 15.44  |  1.46GB |
| hishel.CacheClient - Warm | JSONByteSerializer | 1.95  | 


