### PR TITLE
Adding `.venv` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.venv/
 venv/
 __pycache__/
 .coverage


### PR DESCRIPTION
Today Cursor was telling me:

> The git repository at "/path/to/hishel" has too many active changes, only a subset of Git features will be enabled.

This is because my `.venv` is in the `git status`. From https://docs.astral.sh/uv/guides/projects/#venv:

> The `.venv` folder contains your project's virtual environment

Since this project uses `uv`, let's not include the `.venv` in the `git status`.