### PR TITLE
fix: respect shared option when excluding unstorable headers

### DIFF
--- a/hishel/_core/_spec.py
+++ b/hishel/_core/_spec.py
@@ -996,6 +996,7 @@ def exclude_unstorable_headers(response: Response, is_cache_shared: bool) -> Res
 def refresh_response_headers(
     stored_response: Response,
     revalidation_response: Response,
+    is_cache_shared: bool,
 ) -> Response:
     """
     Updates a stored response's headers with fresh metadata from a 304 response.
@@ -1108,7 +1109,7 @@ def refresh_response_headers(
             stored_response,
             headers=Headers(new_headers),
         ),
-        is_cache_shared=True,  # Assume shared cache for maximum safety
+        is_cache_shared,
     )
 
 
@@ -2245,7 +2246,7 @@ class NeedRevalidation(State):
                 updating_entries=[
                     replace(
                         pair,
-                        response=refresh_response_headers(pair.response, revalidation_response),
+                        response=refresh_response_headers(pair.response, revalidation_response, self.options.shared),
                     )
                     for pair in identified_for_revalidation
                 ],

--- a/tests/_core/spec/test_helper_functions.py
+++ b/tests/_core/spec/test_helper_functions.py
@@ -781,7 +781,7 @@ class TestExcludeUnstorableHeaders:
 
 
 # =============================================================================
-# Test Suite 8: refresh_response_headers
+# Test Suite 8: refresh_response_headers for shared cache
 # =============================================================================
 
 
@@ -791,6 +791,8 @@ class TestRefreshResponseHeaders:
 
     RFC 9111 Section 3.2: Updating Stored Header Fields
     """
+
+    is_cache_shared = True
 
     def test_updates_cache_control_from_304(self) -> None:
         """
@@ -810,7 +812,7 @@ class TestRefreshResponseHeaders:
         revalidation = create_response(status_code=304, headers={"cache-control": "max-age=7200"})
 
         # Act
-        refreshed = refresh_response_headers(stored, revalidation)
+        refreshed = refresh_response_headers(stored, revalidation, self.is_cache_shared)
 
         # Assert
         assert refreshed.headers["cache-control"] == "max-age=7200"
@@ -840,7 +842,7 @@ class TestRefreshResponseHeaders:
         )
 
         # Act
-        refreshed = refresh_response_headers(stored, revalidation)
+        refreshed = refresh_response_headers(stored, revalidation, self.is_cache_shared)
 
         # Assert
         assert refreshed.headers["content-type"] == "application/json"  # Preserved
@@ -866,7 +868,7 @@ class TestRefreshResponseHeaders:
         )
 
         # Act
-        refreshed = refresh_response_headers(stored, revalidation)
+        refreshed = refresh_response_headers(stored, revalidation, self.is_cache_shared)
 
         # Assert
         assert refreshed.headers["content-encoding"] == "gzip"  # Preserved
@@ -891,7 +893,7 @@ class TestRefreshResponseHeaders:
         )
 
         # Act
-        refreshed = refresh_response_headers(stored, revalidation)
+        refreshed = refresh_response_headers(stored, revalidation, self.is_cache_shared)
 
         # Assert
         assert refreshed.headers["content-range"] == "bytes 0-1023/2048"  # Preserved
@@ -917,7 +919,7 @@ class TestRefreshResponseHeaders:
         )
 
         # Act
-        refreshed = refresh_response_headers(stored, revalidation)
+        refreshed = refresh_response_headers(stored, revalidation, self.is_cache_shared)
 
         # Assert
         assert refreshed.headers["date"] == "Mon, 01 Jan 2024 12:00:00 GMT"
@@ -942,9 +944,18 @@ class TestRefreshResponseHeaders:
         )
 
         # Act
-        refreshed = refresh_response_headers(stored, revalidation)
+        refreshed = refresh_response_headers(stored, revalidation, self.is_cache_shared)
 
         # Assert
         assert "cache-control" in refreshed.headers
         assert "connection" not in refreshed.headers
         assert "keep-alive" not in refreshed.headers
+
+
+# =============================================================================
+# Test Suite 9: refresh_response_headers for private cache
+# =============================================================================
+
+
+class TestRefreshResponseHeadersPrivateCache(TestRefreshResponseHeaders):
+    is_cache_shared = False


### PR DESCRIPTION
Here a little refactor to avoid the hardcoded shared cache value at `exclude_unstorable_headers` function.

I did extend the current tests to validate behaviour with private cache, all cases seem to behave exactly the same, maybe we need to create a specific case with `s-maxage` header to see the affectation.