### PR TITLE
fix: set `after_revalidation=True` for `NeedsToBeUpdated` -> `FromCache` transition

### DIFF
--- a/hishel/_core/_spec.py
+++ b/hishel/_core/_spec.py
@@ -2410,4 +2410,4 @@ class NeedToBeUpdated(State):
     original_request: Request
 
     def next(self) -> FromCache:
-        return FromCache(entry=self.updating_entries[-1], options=self.options)
+        return FromCache(entry=self.updating_entries[-1], options=self.options, after_revalidation=True)


### PR DESCRIPTION
@karpetrosyan this is a minimal PR to set FromCache after_revalidation to True on the NeedToBeUpdated to FromCache transition after a revalidation.

This change will allow hishel http clients to detect that this response was fetched properly from the cache after revalidating and obtaining the expected 304 response.