### PR TITLE
fix(cache): Lambda parameter name clashes the loop variable being closed over

### DIFF
--- a/hishel/_async_cache.py
+++ b/hishel/_async_cache.py
@@ -197,12 +197,12 @@ class AsyncCacheProxy:
         return state.next(revalidation_response)
 
     async def _handle_update(self, state: NeedToBeUpdated) -> AnyState:
-        for entry in state.updating_entries:
+        for updating_entry in state.updating_entries:
             await self.storage.update_entry(
-                entry.id,
-                lambda entry: replace(
-                    entry,
-                    response=replace(entry.response, headers=entry.response.headers),
+                updating_entry.id,
+                lambda existing_entry: replace(
+                    existing_entry,
+                    response=replace(existing_entry.response, headers=updating_entry.response.headers),
                 ),
             )
         return state.next()

--- a/hishel/_sync_cache.py
+++ b/hishel/_sync_cache.py
@@ -197,12 +197,12 @@ class SyncCacheProxy:
         return state.next(revalidation_response)
 
     def _handle_update(self, state: NeedToBeUpdated) -> AnyState:
-        for entry in state.updating_entries:
+        for updating_entry in state.updating_entries:
             self.storage.update_entry(
-                entry.id,
-                lambda entry: replace(
-                    entry,
-                    response=replace(entry.response, headers=entry.response.headers),
+                updating_entry.id,
+                lambda existing_entry: replace(
+                    existing_entry,
+                    response=replace(existing_entry.response, headers=updating_entry.response.headers),
                 ),
             )
         return state.next()


### PR DESCRIPTION
The issue is that the last time the cache implementation was updated, the lambda parameter name was changed to the same as the loop variable name, so the lambda is updating the existing record parameter with the existing record (no change).

This issue prevents 304 responses from updating the cached response headers and prevents the client from loading solely from cache on subsequent requests (always NeedRevalidation => NeedToBeUpdatede => FromCache for every 304).