### PR TITLE
feat: add Redis storage with sync and async support

### DIFF
--- a/docs/storages.md
+++ b/docs/storages.md
@@ -89,3 +89,77 @@ storage = AsyncSqliteStorage(refresh_ttl_on_access=True)
 :::
 
 You can also control this on a per-request basis by setting the `hishel_refresh_ttl_on_access` request metadata to `True` or `False`, which overrides the storage default.
+
+## Redis Storage
+
+Redis storage provides fast, in-memory (or persistent) caching backed by a Redis server.
+
+::: code-group
+
+```python [Sync]
+from redis import Redis
+from hishel import RedisStorage
+
+client = Redis(host="localhost", port=6379)
+storage = RedisStorage(client=client)
+```
+
+```python [Async]
+from redis.asyncio import Redis
+from hishel import AsyncRedisStorage
+
+client = Redis(host="localhost", port=6379)
+storage = AsyncRedisStorage(client=client)
+```
+
+:::
+
+### Custom Key Prefix
+
+You can set a custom prefix for all Redis keys. This is useful when sharing a Redis instance across multiple applications:
+
+::: code-group
+
+```python [Sync]
+from redis import Redis
+from hishel import RedisStorage
+
+client = Redis(host="localhost", port=6379)
+storage = RedisStorage(client=client, key_prefix="myapp")
+```
+
+```python [Async]
+from redis.asyncio import Redis
+from hishel import AsyncRedisStorage
+
+client = Redis(host="localhost", port=6379)
+storage = AsyncRedisStorage(client=client, key_prefix="myapp")
+```
+
+:::
+
+### Default Entry TTL
+
+You can set a default TTL for all entries stored in Redis. This value is used when the request does not specify its own TTL:
+
+::: code-group
+
+```python [Sync]
+from redis import Redis
+from hishel import RedisStorage
+
+client = Redis(host="localhost", port=6379)
+storage = RedisStorage(client=client, ttl=3600)
+```
+
+```python [Async]
+from redis.asyncio import Redis
+from hishel import AsyncRedisStorage
+
+client = Redis(host="localhost", port=6379)
+storage = AsyncRedisStorage(client=client, ttl=3600)
+```
+
+:::
+
+Storage also respects the `hishel_ttl` request metadata, which can be used to set a custom TTL for a specific request, overriding the storage default.

--- a/docs/storages.md
+++ b/docs/storages.md
@@ -163,3 +163,31 @@ storage = AsyncRedisStorage(client=client, ttl=3600)
 :::
 
 Storage also respects the `hishel_ttl` request metadata, which can be used to set a custom TTL for a specific request, overriding the storage default.
+
+### Soft-Delete Buffer TTL
+
+When an entry is removed, hishel soft-deletes it (marks `deleted_at`) and sets a short TTL on the underlying Redis keys so that any concurrent request still reading that entry's stream can finish before the data disappears. After the buffer expires, Redis cleans up the keys automatically.
+
+The default buffer is 180 seconds (3 minutes). You can tune it:
+
+::: code-group
+
+```python [Sync]
+from redis import Redis
+from hishel import RedisStorage
+
+client = Redis(host="localhost", port=6379)
+storage = RedisStorage(client=client, soft_delete_ttl=60)
+```
+
+```python [Async]
+from redis.asyncio import Redis
+from hishel import AsyncRedisStorage
+
+client = Redis(host="localhost", port=6379)
+storage = AsyncRedisStorage(client=client, soft_delete_ttl=60)
+```
+
+:::
+
+Soft-deleted entries are invisible to `get_entries`, so new requests will never receive them even while the keys are still present in Redis.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ httpx = [
 fastapi = [
     "fastapi>=0.119.1",
 ]
+redis = [
+    "redis>=6.2.0",
+]
 
 [project.urls]
 Homepage = "https://hishel.com"
@@ -59,8 +62,8 @@ exclude = ['venv', '.venv']
 [[tool.mypy.overrides]]
 module = "tests.*"
 disallow_untyped_defs = false
-
 check_untyped_defs = true
+
 [[tool.mypy.overrides]]
 module = ["time_machine.*", "msgpack.*"]
 ignore_missing_imports = true
@@ -83,8 +86,8 @@ exclude = [
     "src/hishel/_sync_cache.py",
     "tests/test_sync_httpx.py",
     "src/hishel/_core/_storages/_sync_sqlite.py",
+    "src/hishel/_core/_storages/_sync_redis.py",
     "src/hishel/_core/_storages/_sync_base.py",
-    "tests/test_sync_httpx.py",
     "src/hishel/_sync_httpx.py"
 ]
 line-length = 120
@@ -120,5 +123,7 @@ dev = [
     "types-boto3==1.42.39",
     "types-pyyaml==6.0.12.20250915",
     "types-requests>=2.31.0.6",
+    "fakeredis>=2.0",
+    "redis>=6.2.0",
     "zipp>=3.19.1",
 ]

--- a/scripts/unasync
+++ b/scripts/unasync
@@ -27,7 +27,14 @@ SUBS = [
     ("AsyncBaseStorage", "SyncBaseStorage"),
     ("AsyncCacheClient", "SyncCacheClient"),
     ("AsyncSqliteStorage", "SyncSqliteStorage"),
+    ("AsyncRedisStorage", "RedisStorage"),
     ("anysqlite", "sqlite3"),
+    ("redis.asyncio", "redis"),
+    ("fakeredis.aioredis", "fakeredis"),
+    (
+        "hishel._core._storages._async_redis",
+        "hishel._core._storages._sync_redis",
+    ),
     ("@pytest.mark.anyio", ""),
     ("from anyio import Lock", "from threading import RLock"),
     ("self._lock = Lock", "self._lock = RLock"),
@@ -111,6 +118,8 @@ def main():
         ("src/hishel/_async_cache.py", "src/hishel/_sync_cache.py"),
         ("src/hishel/_core/_storages/_async_base.py", "src/hishel/_core/_storages/_sync_base.py"),
         ("src/hishel/_core/_storages/_async_sqlite.py", "src/hishel/_core/_storages/_sync_sqlite.py"),
+        ("src/hishel/_core/_storages/_async_redis.py", "src/hishel/_core/_storages/_sync_redis.py"),
+        ("tests/_core/_async/test_redis_storage.py", "tests/_core/_sync/test_redis_storage.py"),
         ("src/hishel/_async_httpx.py", "src/hishel/_sync_httpx.py"),
     ]
 

--- a/src/hishel/__init__.py
+++ b/src/hishel/__init__.py
@@ -1,7 +1,9 @@
 from hishel._core._storages._async_sqlite import AsyncSqliteStorage
 from hishel._core._storages._async_base import AsyncBaseStorage
+from hishel._core._storages._async_redis import AsyncRedisStorage
 from hishel._core._storages._sync_sqlite import SyncSqliteStorage
 from hishel._core._storages._sync_base import SyncBaseStorage
+from hishel._core._storages._sync_redis import RedisStorage
 from hishel._core._headers import Headers as Headers
 from hishel._core._spec import (
     AnyState as AnyState,
@@ -58,6 +60,8 @@ __all__ = (
     "AsyncBaseStorage",
     "SyncSqliteStorage",
     "AsyncSqliteStorage",
+    "RedisStorage",
+    "AsyncRedisStorage",
     # Proxy
     "AsyncCacheProxy",
     "SyncCacheProxy",

--- a/src/hishel/_core/_storages/_async_redis.py
+++ b/src/hishel/_core/_storages/_async_redis.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import contextlib
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import replace
 from time import time
 from typing import cast
@@ -47,7 +47,7 @@ class AsyncRedisStorage(AsyncBaseStorage):
         else:
             await self._client.set(entry_key, packed)
 
-        await self._client.sadd(idx_key, pair_id.hex)  # type: ignore[misc]
+        await cast(Awaitable[int], self._client.sadd(idx_key, pair_id.hex))
         if self._default_ttl is not None:
             await self._client.expire(idx_key, int(self._default_ttl))
 
@@ -58,11 +58,11 @@ class AsyncRedisStorage(AsyncBaseStorage):
         done_key = f"{self._key_prefix}:stream_done:{pair_id.hex}"
 
         async for chunk in stream:
-            await self._client.rpush(stream_key, chunk)  # type: ignore[misc]
+            await cast(Awaitable[int], self._client.rpush(stream_key, chunk))
             yield chunk
 
         # sentinel to mark end of stream
-        await self._client.rpush(stream_key, b"")  # type: ignore[misc]
+        await cast(Awaitable[int], self._client.rpush(stream_key, b""))
         await self._client.set(done_key, b"1")
         if self._default_ttl is not None:
             await self._client.expire(stream_key, int(self._default_ttl))
@@ -78,15 +78,15 @@ class AsyncRedisStorage(AsyncBaseStorage):
 
     async def _stream_from_cache(self, entry_id: UUID) -> AsyncIterator[bytes]:
         stream_key = f"{self._key_prefix}:stream:{entry_id.hex}"
-        length = cast(int, await self._client.llen(stream_key))  # type: ignore[misc]
+        length = await cast(Awaitable[int], self._client.llen(stream_key))
         for i in range(length - 1):  # -1 excludes the sentinel
-            chunk = cast(bytes | None, await self._client.lindex(stream_key, i))  # type: ignore[misc]
+            chunk = await cast(Awaitable[bytes | None], self._client.lindex(stream_key, i))
             if chunk is not None:
                 yield chunk.encode() if isinstance(chunk, str) else chunk
 
     async def get_entries(self, key: str) -> list[Entry]:
         idx_key = f"{self._key_prefix}:idx:{key}"
-        members = cast(set[bytes], await self._client.smembers(idx_key))  # type: ignore[misc]
+        members = await cast(Awaitable[set[bytes]], self._client.smembers(idx_key))
 
         result: list[Entry] = []
         for member in members:
@@ -95,7 +95,7 @@ class AsyncRedisStorage(AsyncBaseStorage):
 
             data = await self._client.get(entry_key)
             if data is None:
-                await self._client.srem(idx_key, member)  # type: ignore[misc]
+                await cast(Awaitable[int], self._client.srem(idx_key, member))
                 continue
 
             entry = unpack(cast(bytes, data), kind="pair")
@@ -147,8 +147,8 @@ class AsyncRedisStorage(AsyncBaseStorage):
         if existing.cache_key != updated.cache_key:
             old_key = existing.cache_key.decode() if isinstance(existing.cache_key, bytes) else existing.cache_key
             new_key = updated.cache_key.decode() if isinstance(updated.cache_key, bytes) else updated.cache_key
-            await self._client.srem(f"{self._key_prefix}:idx:{old_key}", id.hex)  # type: ignore[misc]
-            await self._client.sadd(f"{self._key_prefix}:idx:{new_key}", id.hex)  # type: ignore[misc]
+            await cast(Awaitable[int], self._client.srem(f"{self._key_prefix}:idx:{old_key}", id.hex))
+            await cast(Awaitable[int], self._client.sadd(f"{self._key_prefix}:idx:{new_key}", id.hex))
 
         return updated
 

--- a/src/hishel/_core/_storages/_async_redis.py
+++ b/src/hishel/_core/_storages/_async_redis.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncIterator, Callable
+from dataclasses import replace
+from time import time
+from typing import cast
+from uuid import UUID, uuid4
+
+from redis import RedisError
+from redis.asyncio import Redis
+
+from hishel._core._storages._async_base import AsyncBaseStorage
+from hishel._core._storages._packing import pack, unpack
+from hishel._core.models import Entry, EntryMeta, Request, Response
+
+
+class AsyncRedisStorage(AsyncBaseStorage):
+    def __init__(self, client: Redis, ttl: int | float | None = None) -> None:
+        self._client = client
+        self._default_ttl = ttl
+
+    async def create_entry(self, request: Request, response: Response, key: str, id_: UUID | None = None) -> Entry:
+        pair_id = id_ or uuid4()
+        key_bytes = key.encode()
+
+        response_with_stream = replace(
+            response,
+            stream=self._save_stream(cast(AsyncIterator[bytes], response.stream), pair_id),
+        )
+
+        entry = Entry(
+            id=pair_id,
+            request=request,
+            response=response_with_stream,
+            meta=EntryMeta(created_at=time()),
+            cache_key=key_bytes,
+        )
+
+        packed = pack(entry, kind="pair")
+        entry_key = f"hishel:entry:{pair_id.hex}"
+        idx_key = f"hishel:idx:{key}"
+
+        if self._default_ttl is not None:
+            await self._client.set(entry_key, packed, ex=int(self._default_ttl))
+        else:
+            await self._client.set(entry_key, packed)
+
+        await self._client.sadd(idx_key, pair_id.hex)  # type: ignore[misc]
+        if self._default_ttl is not None:
+            await self._client.expire(idx_key, int(self._default_ttl))
+
+        return entry
+
+    async def _save_stream(self, stream: AsyncIterator[bytes], pair_id: UUID) -> AsyncIterator[bytes]:
+        stream_key = f"hishel:stream:{pair_id.hex}"
+        done_key = f"hishel:stream_done:{pair_id.hex}"
+
+        async for chunk in stream:
+            await self._client.rpush(stream_key, chunk)  # type: ignore[misc]
+            yield chunk
+
+        # sentinel to mark end of stream
+        await self._client.rpush(stream_key, b"")  # type: ignore[misc]
+        await self._client.set(done_key, b"1")
+        if self._default_ttl is not None:
+            await self._client.expire(stream_key, int(self._default_ttl))
+            await self._client.expire(done_key, int(self._default_ttl))
+
+    async def _is_stream_complete(self, entry_id: UUID) -> bool:
+        result = await self._client.exists(f"hishel:stream_done:{entry_id.hex}")
+        return bool(result)
+
+    def _is_pair_expired(self, pair: Entry) -> bool:
+        ttl = pair.request.metadata.get("hishel_ttl", self._default_ttl)
+        return ttl is not None and pair.meta.created_at + ttl < time()
+
+    async def _stream_from_cache(self, entry_id: UUID) -> AsyncIterator[bytes]:
+        stream_key = f"hishel:stream:{entry_id.hex}"
+        length = cast(int, await self._client.llen(stream_key))  # type: ignore[misc]
+        for i in range(length - 1):  # -1 excludes the sentinel
+            chunk = cast(bytes | None, await self._client.lindex(stream_key, i))  # type: ignore[misc]
+            if chunk is not None:
+                yield chunk.encode() if isinstance(chunk, str) else chunk
+
+    async def get_entries(self, key: str) -> list[Entry]:
+        idx_key = f"hishel:idx:{key}"
+        members = cast(set[bytes], await self._client.smembers(idx_key))  # type: ignore[misc]
+
+        result: list[Entry] = []
+        for member in members:
+            hex_str = member.decode() if isinstance(member, bytes) else member
+            entry_key = f"hishel:entry:{hex_str}"
+
+            data = await self._client.get(entry_key)
+            if data is None:
+                await self._client.srem(idx_key, member)  # type: ignore[misc]
+                continue
+
+            entry = unpack(cast(bytes, data), kind="pair")
+            if entry is None:
+                continue
+
+            if not await self._is_stream_complete(entry.id):
+                continue
+
+            if self._is_pair_expired(entry):
+                continue
+
+            if self.is_soft_deleted(entry):
+                continue
+
+            result.append(
+                replace(
+                    entry,
+                    response=replace(entry.response, stream=self._stream_from_cache(entry.id)),
+                )
+            )
+
+        return result
+
+    async def update_entry(
+        self,
+        id: UUID,  # noqa: A002
+        new_entry: Entry | Callable[[Entry], Entry],
+    ) -> Entry | None:
+        entry_key = f"hishel:entry:{id.hex}"
+        data = await self._client.get(entry_key)
+        if data is None:
+            return None
+
+        existing = unpack(cast(bytes, data), kind="pair")
+
+        updated = new_entry(existing) if callable(new_entry) else new_entry
+
+        if existing.id != updated.id:
+            raise ValueError("Entry ID mismatch")
+
+        pttl = cast(int, await self._client.pttl(entry_key))
+        packed = pack(updated, kind="pair")
+        if pttl > 0:
+            await self._client.set(entry_key, packed, px=pttl)
+        else:
+            await self._client.set(entry_key, packed)
+
+        if existing.cache_key != updated.cache_key:
+            old_key = existing.cache_key.decode() if isinstance(existing.cache_key, bytes) else existing.cache_key
+            new_key = updated.cache_key.decode() if isinstance(updated.cache_key, bytes) else updated.cache_key
+            await self._client.srem(f"hishel:idx:{old_key}", id.hex)  # type: ignore[misc]
+            await self._client.sadd(f"hishel:idx:{new_key}", id.hex)  # type: ignore[misc]
+
+        return updated
+
+    async def remove_entry(self, id: UUID) -> None:  # noqa: A002
+        entry_key = f"hishel:entry:{id.hex}"
+        stream_key = f"hishel:stream:{id.hex}"
+        done_key = f"hishel:stream_done:{id.hex}"
+        with contextlib.suppress(RedisError):
+            # don't let deletes prevent reads; failures are non-fatal
+            await self._client.delete(entry_key, stream_key, done_key)
+
+    async def close(self) -> None:
+        await self._client.aclose()

--- a/src/hishel/_core/_storages/_async_redis.py
+++ b/src/hishel/_core/_storages/_async_redis.py
@@ -16,9 +16,10 @@ from hishel._core.models import Entry, EntryMeta, Request, Response
 
 
 class AsyncRedisStorage(AsyncBaseStorage):
-    def __init__(self, client: Redis, ttl: int | float | None = None) -> None:
+    def __init__(self, client: Redis, ttl: int | float | None = None, key_prefix: str = "hishel") -> None:
         self._client = client
         self._default_ttl = ttl
+        self._key_prefix = key_prefix
 
     async def create_entry(self, request: Request, response: Response, key: str, id_: UUID | None = None) -> Entry:
         pair_id = id_ or uuid4()
@@ -38,8 +39,8 @@ class AsyncRedisStorage(AsyncBaseStorage):
         )
 
         packed = pack(entry, kind="pair")
-        entry_key = f"hishel:entry:{pair_id.hex}"
-        idx_key = f"hishel:idx:{key}"
+        entry_key = f"{self._key_prefix}:entry:{pair_id.hex}"
+        idx_key = f"{self._key_prefix}:idx:{key}"
 
         if self._default_ttl is not None:
             await self._client.set(entry_key, packed, ex=int(self._default_ttl))
@@ -53,8 +54,8 @@ class AsyncRedisStorage(AsyncBaseStorage):
         return entry
 
     async def _save_stream(self, stream: AsyncIterator[bytes], pair_id: UUID) -> AsyncIterator[bytes]:
-        stream_key = f"hishel:stream:{pair_id.hex}"
-        done_key = f"hishel:stream_done:{pair_id.hex}"
+        stream_key = f"{self._key_prefix}:stream:{pair_id.hex}"
+        done_key = f"{self._key_prefix}:stream_done:{pair_id.hex}"
 
         async for chunk in stream:
             await self._client.rpush(stream_key, chunk)  # type: ignore[misc]
@@ -68,7 +69,7 @@ class AsyncRedisStorage(AsyncBaseStorage):
             await self._client.expire(done_key, int(self._default_ttl))
 
     async def _is_stream_complete(self, entry_id: UUID) -> bool:
-        result = await self._client.exists(f"hishel:stream_done:{entry_id.hex}")
+        result = await self._client.exists(f"{self._key_prefix}:stream_done:{entry_id.hex}")
         return bool(result)
 
     def _is_pair_expired(self, pair: Entry) -> bool:
@@ -76,7 +77,7 @@ class AsyncRedisStorage(AsyncBaseStorage):
         return ttl is not None and pair.meta.created_at + ttl < time()
 
     async def _stream_from_cache(self, entry_id: UUID) -> AsyncIterator[bytes]:
-        stream_key = f"hishel:stream:{entry_id.hex}"
+        stream_key = f"{self._key_prefix}:stream:{entry_id.hex}"
         length = cast(int, await self._client.llen(stream_key))  # type: ignore[misc]
         for i in range(length - 1):  # -1 excludes the sentinel
             chunk = cast(bytes | None, await self._client.lindex(stream_key, i))  # type: ignore[misc]
@@ -84,13 +85,13 @@ class AsyncRedisStorage(AsyncBaseStorage):
                 yield chunk.encode() if isinstance(chunk, str) else chunk
 
     async def get_entries(self, key: str) -> list[Entry]:
-        idx_key = f"hishel:idx:{key}"
+        idx_key = f"{self._key_prefix}:idx:{key}"
         members = cast(set[bytes], await self._client.smembers(idx_key))  # type: ignore[misc]
 
         result: list[Entry] = []
         for member in members:
             hex_str = member.decode() if isinstance(member, bytes) else member
-            entry_key = f"hishel:entry:{hex_str}"
+            entry_key = f"{self._key_prefix}:entry:{hex_str}"
 
             data = await self._client.get(entry_key)
             if data is None:
@@ -124,7 +125,7 @@ class AsyncRedisStorage(AsyncBaseStorage):
         id: UUID,  # noqa: A002
         new_entry: Entry | Callable[[Entry], Entry],
     ) -> Entry | None:
-        entry_key = f"hishel:entry:{id.hex}"
+        entry_key = f"{self._key_prefix}:entry:{id.hex}"
         data = await self._client.get(entry_key)
         if data is None:
             return None
@@ -146,15 +147,15 @@ class AsyncRedisStorage(AsyncBaseStorage):
         if existing.cache_key != updated.cache_key:
             old_key = existing.cache_key.decode() if isinstance(existing.cache_key, bytes) else existing.cache_key
             new_key = updated.cache_key.decode() if isinstance(updated.cache_key, bytes) else updated.cache_key
-            await self._client.srem(f"hishel:idx:{old_key}", id.hex)  # type: ignore[misc]
-            await self._client.sadd(f"hishel:idx:{new_key}", id.hex)  # type: ignore[misc]
+            await self._client.srem(f"{self._key_prefix}:idx:{old_key}", id.hex)  # type: ignore[misc]
+            await self._client.sadd(f"{self._key_prefix}:idx:{new_key}", id.hex)  # type: ignore[misc]
 
         return updated
 
     async def remove_entry(self, id: UUID) -> None:  # noqa: A002
-        entry_key = f"hishel:entry:{id.hex}"
-        stream_key = f"hishel:stream:{id.hex}"
-        done_key = f"hishel:stream_done:{id.hex}"
+        entry_key = f"{self._key_prefix}:entry:{id.hex}"
+        stream_key = f"{self._key_prefix}:stream:{id.hex}"
+        done_key = f"{self._key_prefix}:stream_done:{id.hex}"
         with contextlib.suppress(RedisError):
             # don't let deletes prevent reads; failures are non-fatal
             await self._client.delete(entry_key, stream_key, done_key)

--- a/src/hishel/_core/_storages/_async_redis.py
+++ b/src/hishel/_core/_storages/_async_redis.py
@@ -150,12 +150,27 @@ try:
             if existing.id != updated.id:
                 raise ValueError("Entry ID mismatch")
 
-            pttl = cast(int, await self._client.pttl(entry_key))
             packed = pack(updated, kind="pair")
-            if pttl > 0:
-                await self._client.set(entry_key, packed, px=pttl)
+
+            if updated.meta.created_at != existing.meta.created_at:
+                # TTL refresh: reset all keys to the full original TTL
+                ttl = self._effective_ttl(updated.request)
+                if ttl is not None:
+                    pttl_ms = int(ttl * 1000)
+                    stream_key = f"{self._key_prefix}:stream:{id.hex}"
+                    done_key = f"{self._key_prefix}:stream_done:{id.hex}"
+                    await self._client.set(entry_key, packed, px=pttl_ms)
+                    await cast(Awaitable[int], self._client.pexpire(stream_key, pttl_ms))
+                    await cast(Awaitable[int], self._client.pexpire(done_key, pttl_ms))
+                else:
+                    await self._client.set(entry_key, packed)
             else:
-                await self._client.set(entry_key, packed)
+                # Regular update: preserve remaining TTL
+                pttl = cast(int, await self._client.pttl(entry_key))
+                if pttl > 0:
+                    await self._client.set(entry_key, packed, px=pttl)
+                else:
+                    await self._client.set(entry_key, packed)
 
             if existing.cache_key != updated.cache_key:
                 old_key = existing.cache_key.decode() if isinstance(existing.cache_key, bytes) else existing.cache_key

--- a/src/hishel/_core/_storages/_async_redis.py
+++ b/src/hishel/_core/_storages/_async_redis.py
@@ -16,10 +16,17 @@ try:
     from redis.asyncio import Redis
 
     class AsyncRedisStorage(AsyncBaseStorage):
-        def __init__(self, client: Redis, ttl: int | float | None = None, key_prefix: str = "hishel") -> None:
+        def __init__(
+            self,
+            client: Redis,
+            ttl: int | float | None = None,
+            key_prefix: str = "hishel",
+            soft_delete_ttl: int = 180,
+        ) -> None:
             self._client = client
             self._default_ttl = ttl
             self._key_prefix = key_prefix
+            self._soft_delete_ttl = soft_delete_ttl
 
         def _effective_ttl(self, request: Request) -> int | float | None:
             return request.metadata.get("hishel_ttl", self._default_ttl)
@@ -163,8 +170,17 @@ try:
             stream_key = f"{self._key_prefix}:stream:{id.hex}"
             done_key = f"{self._key_prefix}:stream_done:{id.hex}"
             with contextlib.suppress(RedisError):
-                # don't let deletes prevent reads; failures are non-fatal
-                await self._client.delete(entry_key, stream_key, done_key)
+                data = await self._client.get(entry_key)
+                if data is None:
+                    return
+                entry = unpack(cast(bytes, data), kind="pair")
+                if entry is None:
+                    return
+                updated = self.mark_pair_as_deleted(entry)
+                packed = pack(updated, kind="pair")
+                await self._client.set(entry_key, packed, ex=self._soft_delete_ttl)
+                await self._client.expire(stream_key, self._soft_delete_ttl)
+                await self._client.expire(done_key, self._soft_delete_ttl)
 
         async def close(self) -> None:
             await self._client.aclose()

--- a/src/hishel/_core/_storages/_async_redis.py
+++ b/src/hishel/_core/_storages/_async_redis.py
@@ -54,13 +54,13 @@ try:
             idx_key = f"{self._key_prefix}:idx:{key}"
 
             if ttl is not None:
-                await self._client.set(entry_key, packed, ex=int(ttl))
+                await self._client.set(entry_key, packed, px=int(ttl * 1000))
             else:
                 await self._client.set(entry_key, packed)
 
             await cast(Awaitable[int], self._client.sadd(idx_key, pair_id.hex))
             if ttl is not None:
-                await self._client.expire(idx_key, int(ttl))
+                await cast(Awaitable[int], self._client.pexpire(idx_key, int(ttl * 1000)))
 
             return entry
 
@@ -78,8 +78,8 @@ try:
             await cast(Awaitable[int], self._client.rpush(stream_key, b""))
             await self._client.set(done_key, b"1")
             if ttl is not None:
-                await self._client.expire(stream_key, int(ttl))
-                await self._client.expire(done_key, int(ttl))
+                await cast(Awaitable[int], self._client.pexpire(stream_key, int(ttl * 1000)))
+                await cast(Awaitable[int], self._client.pexpire(done_key, int(ttl * 1000)))
 
         async def _is_stream_complete(self, entry_id: UUID) -> bool:
             result = await self._client.exists(f"{self._key_prefix}:stream_done:{entry_id.hex}")

--- a/src/hishel/_core/_storages/_async_redis.py
+++ b/src/hishel/_core/_storages/_async_redis.py
@@ -4,165 +4,176 @@ import contextlib
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import replace
 from time import time
-from typing import cast
+from typing import Any, cast
 from uuid import UUID, uuid4
-
-from redis import RedisError
-from redis.asyncio import Redis
 
 from hishel._core._storages._async_base import AsyncBaseStorage
 from hishel._core._storages._packing import pack, unpack
 from hishel._core.models import Entry, EntryMeta, Request, Response
 
+try:
+    from redis import RedisError
+    from redis.asyncio import Redis
 
-class AsyncRedisStorage(AsyncBaseStorage):
-    def __init__(self, client: Redis, ttl: int | float | None = None, key_prefix: str = "hishel") -> None:
-        self._client = client
-        self._default_ttl = ttl
-        self._key_prefix = key_prefix
+    class AsyncRedisStorage(AsyncBaseStorage):
+        def __init__(self, client: Redis, ttl: int | float | None = None, key_prefix: str = "hishel") -> None:
+            self._client = client
+            self._default_ttl = ttl
+            self._key_prefix = key_prefix
 
-    def _effective_ttl(self, request: Request) -> int | float | None:
-        return request.metadata.get("hishel_ttl", self._default_ttl)
+        def _effective_ttl(self, request: Request) -> int | float | None:
+            return request.metadata.get("hishel_ttl", self._default_ttl)
 
-    async def create_entry(self, request: Request, response: Response, key: str, id_: UUID | None = None) -> Entry:
-        pair_id = id_ or uuid4()
-        key_bytes = key.encode()
-        ttl = self._effective_ttl(request)
+        async def create_entry(self, request: Request, response: Response, key: str, id_: UUID | None = None) -> Entry:
+            pair_id = id_ or uuid4()
+            key_bytes = key.encode()
+            ttl = self._effective_ttl(request)
 
-        response_with_stream = replace(
-            response,
-            stream=self._save_stream(cast(AsyncIterator[bytes], response.stream), pair_id, ttl),
-        )
-
-        entry = Entry(
-            id=pair_id,
-            request=request,
-            response=response_with_stream,
-            meta=EntryMeta(created_at=time()),
-            cache_key=key_bytes,
-        )
-
-        packed = pack(entry, kind="pair")
-        entry_key = f"{self._key_prefix}:entry:{pair_id.hex}"
-        idx_key = f"{self._key_prefix}:idx:{key}"
-
-        if ttl is not None:
-            await self._client.set(entry_key, packed, ex=int(ttl))
-        else:
-            await self._client.set(entry_key, packed)
-
-        await cast(Awaitable[int], self._client.sadd(idx_key, pair_id.hex))
-        if ttl is not None:
-            await self._client.expire(idx_key, int(ttl))
-
-        return entry
-
-    async def _save_stream(self, stream: AsyncIterator[bytes], pair_id: UUID, ttl: int | float | None) -> AsyncIterator[bytes]:
-        stream_key = f"{self._key_prefix}:stream:{pair_id.hex}"
-        done_key = f"{self._key_prefix}:stream_done:{pair_id.hex}"
-
-        async for chunk in stream:
-            await cast(Awaitable[int], self._client.rpush(stream_key, chunk))
-            yield chunk
-
-        # sentinel to mark end of stream
-        await cast(Awaitable[int], self._client.rpush(stream_key, b""))
-        await self._client.set(done_key, b"1")
-        if ttl is not None:
-            await self._client.expire(stream_key, int(ttl))
-            await self._client.expire(done_key, int(ttl))
-
-    async def _is_stream_complete(self, entry_id: UUID) -> bool:
-        result = await self._client.exists(f"{self._key_prefix}:stream_done:{entry_id.hex}")
-        return bool(result)
-
-    def _is_pair_expired(self, pair: Entry) -> bool:
-        ttl = self._effective_ttl(pair.request)
-        return ttl is not None and pair.meta.created_at + ttl < time()
-
-    async def _stream_from_cache(self, entry_id: UUID) -> AsyncIterator[bytes]:
-        stream_key = f"{self._key_prefix}:stream:{entry_id.hex}"
-        length = await cast(Awaitable[int], self._client.llen(stream_key))
-        for i in range(length - 1):  # -1 excludes the sentinel
-            chunk = await cast(Awaitable[bytes | None], self._client.lindex(stream_key, i))
-            if chunk is not None:
-                yield chunk.encode() if isinstance(chunk, str) else chunk
-
-    async def get_entries(self, key: str) -> list[Entry]:
-        idx_key = f"{self._key_prefix}:idx:{key}"
-        members = await cast(Awaitable[set[bytes]], self._client.smembers(idx_key))
-
-        result: list[Entry] = []
-        for member in members:
-            hex_str = member.decode() if isinstance(member, bytes) else member
-            entry_key = f"{self._key_prefix}:entry:{hex_str}"
-
-            data = await self._client.get(entry_key)
-            if data is None:
-                await cast(Awaitable[int], self._client.srem(idx_key, member))
-                continue
-
-            entry = unpack(cast(bytes, data), kind="pair")
-            if entry is None:
-                continue
-
-            if not await self._is_stream_complete(entry.id):
-                continue
-
-            if self._is_pair_expired(entry):
-                continue
-
-            if self.is_soft_deleted(entry):
-                continue
-
-            result.append(
-                replace(
-                    entry,
-                    response=replace(entry.response, stream=self._stream_from_cache(entry.id)),
-                )
+            response_with_stream = replace(
+                response,
+                stream=self._save_stream(cast(AsyncIterator[bytes], response.stream), pair_id, ttl),
             )
 
-        return result
+            entry = Entry(
+                id=pair_id,
+                request=request,
+                response=response_with_stream,
+                meta=EntryMeta(created_at=time()),
+                cache_key=key_bytes,
+            )
 
-    async def update_entry(
-        self,
-        id: UUID,  # noqa: A002
-        new_entry: Entry | Callable[[Entry], Entry],
-    ) -> Entry | None:
-        entry_key = f"{self._key_prefix}:entry:{id.hex}"
-        data = await self._client.get(entry_key)
-        if data is None:
-            return None
+            packed = pack(entry, kind="pair")
+            entry_key = f"{self._key_prefix}:entry:{pair_id.hex}"
+            idx_key = f"{self._key_prefix}:idx:{key}"
 
-        existing = unpack(cast(bytes, data), kind="pair")
+            if ttl is not None:
+                await self._client.set(entry_key, packed, ex=int(ttl))
+            else:
+                await self._client.set(entry_key, packed)
 
-        updated = new_entry(existing) if callable(new_entry) else new_entry
+            await cast(Awaitable[int], self._client.sadd(idx_key, pair_id.hex))
+            if ttl is not None:
+                await self._client.expire(idx_key, int(ttl))
 
-        if existing.id != updated.id:
-            raise ValueError("Entry ID mismatch")
+            return entry
 
-        pttl = cast(int, await self._client.pttl(entry_key))
-        packed = pack(updated, kind="pair")
-        if pttl > 0:
-            await self._client.set(entry_key, packed, px=pttl)
-        else:
-            await self._client.set(entry_key, packed)
+        async def _save_stream(
+            self, stream: AsyncIterator[bytes], pair_id: UUID, ttl: int | float | None
+        ) -> AsyncIterator[bytes]:
+            stream_key = f"{self._key_prefix}:stream:{pair_id.hex}"
+            done_key = f"{self._key_prefix}:stream_done:{pair_id.hex}"
 
-        if existing.cache_key != updated.cache_key:
-            old_key = existing.cache_key.decode() if isinstance(existing.cache_key, bytes) else existing.cache_key
-            new_key = updated.cache_key.decode() if isinstance(updated.cache_key, bytes) else updated.cache_key
-            await cast(Awaitable[int], self._client.srem(f"{self._key_prefix}:idx:{old_key}", id.hex))
-            await cast(Awaitable[int], self._client.sadd(f"{self._key_prefix}:idx:{new_key}", id.hex))
+            async for chunk in stream:
+                await cast(Awaitable[int], self._client.rpush(stream_key, chunk))
+                yield chunk
 
-        return updated
+            # sentinel to mark end of stream
+            await cast(Awaitable[int], self._client.rpush(stream_key, b""))
+            await self._client.set(done_key, b"1")
+            if ttl is not None:
+                await self._client.expire(stream_key, int(ttl))
+                await self._client.expire(done_key, int(ttl))
 
-    async def remove_entry(self, id: UUID) -> None:  # noqa: A002
-        entry_key = f"{self._key_prefix}:entry:{id.hex}"
-        stream_key = f"{self._key_prefix}:stream:{id.hex}"
-        done_key = f"{self._key_prefix}:stream_done:{id.hex}"
-        with contextlib.suppress(RedisError):
-            # don't let deletes prevent reads; failures are non-fatal
-            await self._client.delete(entry_key, stream_key, done_key)
+        async def _is_stream_complete(self, entry_id: UUID) -> bool:
+            result = await self._client.exists(f"{self._key_prefix}:stream_done:{entry_id.hex}")
+            return bool(result)
 
-    async def close(self) -> None:
-        await self._client.aclose()
+        def _is_pair_expired(self, pair: Entry) -> bool:
+            ttl = self._effective_ttl(pair.request)
+            return ttl is not None and pair.meta.created_at + ttl < time()
+
+        async def _stream_from_cache(self, entry_id: UUID) -> AsyncIterator[bytes]:
+            stream_key = f"{self._key_prefix}:stream:{entry_id.hex}"
+            length = await cast(Awaitable[int], self._client.llen(stream_key))
+            for i in range(length - 1):  # -1 excludes the sentinel
+                chunk = await cast(Awaitable[bytes | None], self._client.lindex(stream_key, i))
+                if chunk is not None:
+                    yield chunk.encode() if isinstance(chunk, str) else chunk
+
+        async def get_entries(self, key: str) -> list[Entry]:
+            idx_key = f"{self._key_prefix}:idx:{key}"
+            members = await cast(Awaitable[set[bytes]], self._client.smembers(idx_key))
+
+            result: list[Entry] = []
+            for member in members:
+                hex_str = member.decode() if isinstance(member, bytes) else member
+                entry_key = f"{self._key_prefix}:entry:{hex_str}"
+
+                data = await self._client.get(entry_key)
+                if data is None:
+                    await cast(Awaitable[int], self._client.srem(idx_key, member))
+                    continue
+
+                entry = unpack(cast(bytes, data), kind="pair")
+                if entry is None:
+                    continue
+
+                if not await self._is_stream_complete(entry.id):
+                    continue
+
+                if self._is_pair_expired(entry):
+                    continue
+
+                if self.is_soft_deleted(entry):
+                    continue
+
+                result.append(
+                    replace(
+                        entry,
+                        response=replace(entry.response, stream=self._stream_from_cache(entry.id)),
+                    )
+                )
+
+            return result
+
+        async def update_entry(
+            self,
+            id: UUID,  # noqa: A002
+            new_entry: Entry | Callable[[Entry], Entry],
+        ) -> Entry | None:
+            entry_key = f"{self._key_prefix}:entry:{id.hex}"
+            data = await self._client.get(entry_key)
+            if data is None:
+                return None
+
+            existing = unpack(cast(bytes, data), kind="pair")
+
+            updated = new_entry(existing) if callable(new_entry) else new_entry
+
+            if existing.id != updated.id:
+                raise ValueError("Entry ID mismatch")
+
+            pttl = cast(int, await self._client.pttl(entry_key))
+            packed = pack(updated, kind="pair")
+            if pttl > 0:
+                await self._client.set(entry_key, packed, px=pttl)
+            else:
+                await self._client.set(entry_key, packed)
+
+            if existing.cache_key != updated.cache_key:
+                old_key = existing.cache_key.decode() if isinstance(existing.cache_key, bytes) else existing.cache_key
+                new_key = updated.cache_key.decode() if isinstance(updated.cache_key, bytes) else updated.cache_key
+                await cast(Awaitable[int], self._client.srem(f"{self._key_prefix}:idx:{old_key}", id.hex))
+                await cast(Awaitable[int], self._client.sadd(f"{self._key_prefix}:idx:{new_key}", id.hex))
+
+            return updated
+
+        async def remove_entry(self, id: UUID) -> None:  # noqa: A002
+            entry_key = f"{self._key_prefix}:entry:{id.hex}"
+            stream_key = f"{self._key_prefix}:stream:{id.hex}"
+            done_key = f"{self._key_prefix}:stream_done:{id.hex}"
+            with contextlib.suppress(RedisError):
+                # don't let deletes prevent reads; failures are non-fatal
+                await self._client.delete(entry_key, stream_key, done_key)
+
+        async def close(self) -> None:
+            await self._client.aclose()
+
+except ImportError:
+
+    class AsyncRedisStorage:  # type: ignore[no-redef]
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            raise ImportError(
+                "The 'redis' library is required to use the `AsyncRedisStorage` integration. "
+                "Install hishel with 'pip install hishel[redis]'."
+            )

--- a/src/hishel/_core/_storages/_async_redis.py
+++ b/src/hishel/_core/_storages/_async_redis.py
@@ -21,13 +21,17 @@ class AsyncRedisStorage(AsyncBaseStorage):
         self._default_ttl = ttl
         self._key_prefix = key_prefix
 
+    def _effective_ttl(self, request: Request) -> int | float | None:
+        return request.metadata.get("hishel_ttl", self._default_ttl)
+
     async def create_entry(self, request: Request, response: Response, key: str, id_: UUID | None = None) -> Entry:
         pair_id = id_ or uuid4()
         key_bytes = key.encode()
+        ttl = self._effective_ttl(request)
 
         response_with_stream = replace(
             response,
-            stream=self._save_stream(cast(AsyncIterator[bytes], response.stream), pair_id),
+            stream=self._save_stream(cast(AsyncIterator[bytes], response.stream), pair_id, ttl),
         )
 
         entry = Entry(
@@ -42,18 +46,18 @@ class AsyncRedisStorage(AsyncBaseStorage):
         entry_key = f"{self._key_prefix}:entry:{pair_id.hex}"
         idx_key = f"{self._key_prefix}:idx:{key}"
 
-        if self._default_ttl is not None:
-            await self._client.set(entry_key, packed, ex=int(self._default_ttl))
+        if ttl is not None:
+            await self._client.set(entry_key, packed, ex=int(ttl))
         else:
             await self._client.set(entry_key, packed)
 
         await cast(Awaitable[int], self._client.sadd(idx_key, pair_id.hex))
-        if self._default_ttl is not None:
-            await self._client.expire(idx_key, int(self._default_ttl))
+        if ttl is not None:
+            await self._client.expire(idx_key, int(ttl))
 
         return entry
 
-    async def _save_stream(self, stream: AsyncIterator[bytes], pair_id: UUID) -> AsyncIterator[bytes]:
+    async def _save_stream(self, stream: AsyncIterator[bytes], pair_id: UUID, ttl: int | float | None) -> AsyncIterator[bytes]:
         stream_key = f"{self._key_prefix}:stream:{pair_id.hex}"
         done_key = f"{self._key_prefix}:stream_done:{pair_id.hex}"
 
@@ -64,16 +68,16 @@ class AsyncRedisStorage(AsyncBaseStorage):
         # sentinel to mark end of stream
         await cast(Awaitable[int], self._client.rpush(stream_key, b""))
         await self._client.set(done_key, b"1")
-        if self._default_ttl is not None:
-            await self._client.expire(stream_key, int(self._default_ttl))
-            await self._client.expire(done_key, int(self._default_ttl))
+        if ttl is not None:
+            await self._client.expire(stream_key, int(ttl))
+            await self._client.expire(done_key, int(ttl))
 
     async def _is_stream_complete(self, entry_id: UUID) -> bool:
         result = await self._client.exists(f"{self._key_prefix}:stream_done:{entry_id.hex}")
         return bool(result)
 
     def _is_pair_expired(self, pair: Entry) -> bool:
-        ttl = pair.request.metadata.get("hishel_ttl", self._default_ttl)
+        ttl = self._effective_ttl(pair.request)
         return ttl is not None and pair.meta.created_at + ttl < time()
 
     async def _stream_from_cache(self, entry_id: UUID) -> AsyncIterator[bytes]:

--- a/src/hishel/_core/_storages/_sync_redis.py
+++ b/src/hishel/_core/_storages/_sync_redis.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import contextlib
-from collections.abc import Iterator, Callable
+from collections.abc import Iterator, Awaitable, Callable
 from dataclasses import replace
 from time import time
 from typing import cast
@@ -47,7 +47,7 @@ class RedisStorage(SyncBaseStorage):
         else:
             self._client.set(entry_key, packed)
 
-        self._client.sadd(idx_key, pair_id.hex)  # type: ignore[misc]
+        cast(int, self._client.sadd(idx_key, pair_id.hex))
         if self._default_ttl is not None:
             self._client.expire(idx_key, int(self._default_ttl))
 
@@ -58,11 +58,11 @@ class RedisStorage(SyncBaseStorage):
         done_key = f"{self._key_prefix}:stream_done:{pair_id.hex}"
 
         for chunk in stream:
-            self._client.rpush(stream_key, chunk)  # type: ignore[misc]
+            cast(int, self._client.rpush(stream_key, chunk))
             yield chunk
 
         # sentinel to mark end of stream
-        self._client.rpush(stream_key, b"")  # type: ignore[misc]
+        cast(int, self._client.rpush(stream_key, b""))
         self._client.set(done_key, b"1")
         if self._default_ttl is not None:
             self._client.expire(stream_key, int(self._default_ttl))
@@ -78,15 +78,15 @@ class RedisStorage(SyncBaseStorage):
 
     def _stream_from_cache(self, entry_id: UUID) -> Iterator[bytes]:
         stream_key = f"{self._key_prefix}:stream:{entry_id.hex}"
-        length = cast(int, self._client.llen(stream_key))  # type: ignore[misc]
+        length = cast(int, self._client.llen(stream_key))
         for i in range(length - 1):  # -1 excludes the sentinel
-            chunk = cast(bytes | None, self._client.lindex(stream_key, i))  # type: ignore[misc]
+            chunk = cast(bytes | None, self._client.lindex(stream_key, i))
             if chunk is not None:
                 yield chunk.encode() if isinstance(chunk, str) else chunk
 
     def get_entries(self, key: str) -> list[Entry]:
         idx_key = f"{self._key_prefix}:idx:{key}"
-        members = cast(set[bytes], self._client.smembers(idx_key))  # type: ignore[misc]
+        members = cast(set[bytes], self._client.smembers(idx_key))
 
         result: list[Entry] = []
         for member in members:
@@ -95,7 +95,7 @@ class RedisStorage(SyncBaseStorage):
 
             data = self._client.get(entry_key)
             if data is None:
-                self._client.srem(idx_key, member)  # type: ignore[misc]
+                cast(int, self._client.srem(idx_key, member))
                 continue
 
             entry = unpack(cast(bytes, data), kind="pair")
@@ -147,8 +147,8 @@ class RedisStorage(SyncBaseStorage):
         if existing.cache_key != updated.cache_key:
             old_key = existing.cache_key.decode() if isinstance(existing.cache_key, bytes) else existing.cache_key
             new_key = updated.cache_key.decode() if isinstance(updated.cache_key, bytes) else updated.cache_key
-            self._client.srem(f"{self._key_prefix}:idx:{old_key}", id.hex)  # type: ignore[misc]
-            self._client.sadd(f"{self._key_prefix}:idx:{new_key}", id.hex)  # type: ignore[misc]
+            cast(int, self._client.srem(f"{self._key_prefix}:idx:{old_key}", id.hex))
+            cast(int, self._client.sadd(f"{self._key_prefix}:idx:{new_key}", id.hex))
 
         return updated
 

--- a/src/hishel/_core/_storages/_sync_redis.py
+++ b/src/hishel/_core/_storages/_sync_redis.py
@@ -16,9 +16,10 @@ from hishel._core.models import Entry, EntryMeta, Request, Response
 
 
 class RedisStorage(SyncBaseStorage):
-    def __init__(self, client: Redis, ttl: int | float | None = None) -> None:
+    def __init__(self, client: Redis, ttl: int | float | None = None, key_prefix: str = "hishel") -> None:
         self._client = client
         self._default_ttl = ttl
+        self._key_prefix = key_prefix
 
     def create_entry(self, request: Request, response: Response, key: str, id_: UUID | None = None) -> Entry:
         pair_id = id_ or uuid4()
@@ -38,8 +39,8 @@ class RedisStorage(SyncBaseStorage):
         )
 
         packed = pack(entry, kind="pair")
-        entry_key = f"hishel:entry:{pair_id.hex}"
-        idx_key = f"hishel:idx:{key}"
+        entry_key = f"{self._key_prefix}:entry:{pair_id.hex}"
+        idx_key = f"{self._key_prefix}:idx:{key}"
 
         if self._default_ttl is not None:
             self._client.set(entry_key, packed, ex=int(self._default_ttl))
@@ -53,8 +54,8 @@ class RedisStorage(SyncBaseStorage):
         return entry
 
     def _save_stream(self, stream: Iterator[bytes], pair_id: UUID) -> Iterator[bytes]:
-        stream_key = f"hishel:stream:{pair_id.hex}"
-        done_key = f"hishel:stream_done:{pair_id.hex}"
+        stream_key = f"{self._key_prefix}:stream:{pair_id.hex}"
+        done_key = f"{self._key_prefix}:stream_done:{pair_id.hex}"
 
         for chunk in stream:
             self._client.rpush(stream_key, chunk)  # type: ignore[misc]
@@ -68,7 +69,7 @@ class RedisStorage(SyncBaseStorage):
             self._client.expire(done_key, int(self._default_ttl))
 
     def _is_stream_complete(self, entry_id: UUID) -> bool:
-        result = self._client.exists(f"hishel:stream_done:{entry_id.hex}")
+        result = self._client.exists(f"{self._key_prefix}:stream_done:{entry_id.hex}")
         return bool(result)
 
     def _is_pair_expired(self, pair: Entry) -> bool:
@@ -76,7 +77,7 @@ class RedisStorage(SyncBaseStorage):
         return ttl is not None and pair.meta.created_at + ttl < time()
 
     def _stream_from_cache(self, entry_id: UUID) -> Iterator[bytes]:
-        stream_key = f"hishel:stream:{entry_id.hex}"
+        stream_key = f"{self._key_prefix}:stream:{entry_id.hex}"
         length = cast(int, self._client.llen(stream_key))  # type: ignore[misc]
         for i in range(length - 1):  # -1 excludes the sentinel
             chunk = cast(bytes | None, self._client.lindex(stream_key, i))  # type: ignore[misc]
@@ -84,13 +85,13 @@ class RedisStorage(SyncBaseStorage):
                 yield chunk.encode() if isinstance(chunk, str) else chunk
 
     def get_entries(self, key: str) -> list[Entry]:
-        idx_key = f"hishel:idx:{key}"
+        idx_key = f"{self._key_prefix}:idx:{key}"
         members = cast(set[bytes], self._client.smembers(idx_key))  # type: ignore[misc]
 
         result: list[Entry] = []
         for member in members:
             hex_str = member.decode() if isinstance(member, bytes) else member
-            entry_key = f"hishel:entry:{hex_str}"
+            entry_key = f"{self._key_prefix}:entry:{hex_str}"
 
             data = self._client.get(entry_key)
             if data is None:
@@ -124,7 +125,7 @@ class RedisStorage(SyncBaseStorage):
         id: UUID,  # noqa: A002
         new_entry: Entry | Callable[[Entry], Entry],
     ) -> Entry | None:
-        entry_key = f"hishel:entry:{id.hex}"
+        entry_key = f"{self._key_prefix}:entry:{id.hex}"
         data = self._client.get(entry_key)
         if data is None:
             return None
@@ -146,15 +147,15 @@ class RedisStorage(SyncBaseStorage):
         if existing.cache_key != updated.cache_key:
             old_key = existing.cache_key.decode() if isinstance(existing.cache_key, bytes) else existing.cache_key
             new_key = updated.cache_key.decode() if isinstance(updated.cache_key, bytes) else updated.cache_key
-            self._client.srem(f"hishel:idx:{old_key}", id.hex)  # type: ignore[misc]
-            self._client.sadd(f"hishel:idx:{new_key}", id.hex)  # type: ignore[misc]
+            self._client.srem(f"{self._key_prefix}:idx:{old_key}", id.hex)  # type: ignore[misc]
+            self._client.sadd(f"{self._key_prefix}:idx:{new_key}", id.hex)  # type: ignore[misc]
 
         return updated
 
     def remove_entry(self, id: UUID) -> None:  # noqa: A002
-        entry_key = f"hishel:entry:{id.hex}"
-        stream_key = f"hishel:stream:{id.hex}"
-        done_key = f"hishel:stream_done:{id.hex}"
+        entry_key = f"{self._key_prefix}:entry:{id.hex}"
+        stream_key = f"{self._key_prefix}:stream:{id.hex}"
+        done_key = f"{self._key_prefix}:stream_done:{id.hex}"
         with contextlib.suppress(RedisError):
             # don't let deletes prevent reads; failures are non-fatal
             self._client.delete(entry_key, stream_key, done_key)

--- a/src/hishel/_core/_storages/_sync_redis.py
+++ b/src/hishel/_core/_storages/_sync_redis.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Iterator, Callable
+from dataclasses import replace
+from time import time
+from typing import cast
+from uuid import UUID, uuid4
+
+from redis import RedisError
+from redis import Redis
+
+from hishel._core._storages._sync_base import SyncBaseStorage
+from hishel._core._storages._packing import pack, unpack
+from hishel._core.models import Entry, EntryMeta, Request, Response
+
+
+class RedisStorage(SyncBaseStorage):
+    def __init__(self, client: Redis, ttl: int | float | None = None) -> None:
+        self._client = client
+        self._default_ttl = ttl
+
+    def create_entry(self, request: Request, response: Response, key: str, id_: UUID | None = None) -> Entry:
+        pair_id = id_ or uuid4()
+        key_bytes = key.encode()
+
+        response_with_stream = replace(
+            response,
+            stream=self._save_stream(cast(Iterator[bytes], response.stream), pair_id),
+        )
+
+        entry = Entry(
+            id=pair_id,
+            request=request,
+            response=response_with_stream,
+            meta=EntryMeta(created_at=time()),
+            cache_key=key_bytes,
+        )
+
+        packed = pack(entry, kind="pair")
+        entry_key = f"hishel:entry:{pair_id.hex}"
+        idx_key = f"hishel:idx:{key}"
+
+        if self._default_ttl is not None:
+            self._client.set(entry_key, packed, ex=int(self._default_ttl))
+        else:
+            self._client.set(entry_key, packed)
+
+        self._client.sadd(idx_key, pair_id.hex)  # type: ignore[misc]
+        if self._default_ttl is not None:
+            self._client.expire(idx_key, int(self._default_ttl))
+
+        return entry
+
+    def _save_stream(self, stream: Iterator[bytes], pair_id: UUID) -> Iterator[bytes]:
+        stream_key = f"hishel:stream:{pair_id.hex}"
+        done_key = f"hishel:stream_done:{pair_id.hex}"
+
+        for chunk in stream:
+            self._client.rpush(stream_key, chunk)  # type: ignore[misc]
+            yield chunk
+
+        # sentinel to mark end of stream
+        self._client.rpush(stream_key, b"")  # type: ignore[misc]
+        self._client.set(done_key, b"1")
+        if self._default_ttl is not None:
+            self._client.expire(stream_key, int(self._default_ttl))
+            self._client.expire(done_key, int(self._default_ttl))
+
+    def _is_stream_complete(self, entry_id: UUID) -> bool:
+        result = self._client.exists(f"hishel:stream_done:{entry_id.hex}")
+        return bool(result)
+
+    def _is_pair_expired(self, pair: Entry) -> bool:
+        ttl = pair.request.metadata.get("hishel_ttl", self._default_ttl)
+        return ttl is not None and pair.meta.created_at + ttl < time()
+
+    def _stream_from_cache(self, entry_id: UUID) -> Iterator[bytes]:
+        stream_key = f"hishel:stream:{entry_id.hex}"
+        length = cast(int, self._client.llen(stream_key))  # type: ignore[misc]
+        for i in range(length - 1):  # -1 excludes the sentinel
+            chunk = cast(bytes | None, self._client.lindex(stream_key, i))  # type: ignore[misc]
+            if chunk is not None:
+                yield chunk.encode() if isinstance(chunk, str) else chunk
+
+    def get_entries(self, key: str) -> list[Entry]:
+        idx_key = f"hishel:idx:{key}"
+        members = cast(set[bytes], self._client.smembers(idx_key))  # type: ignore[misc]
+
+        result: list[Entry] = []
+        for member in members:
+            hex_str = member.decode() if isinstance(member, bytes) else member
+            entry_key = f"hishel:entry:{hex_str}"
+
+            data = self._client.get(entry_key)
+            if data is None:
+                self._client.srem(idx_key, member)  # type: ignore[misc]
+                continue
+
+            entry = unpack(cast(bytes, data), kind="pair")
+            if entry is None:
+                continue
+
+            if not self._is_stream_complete(entry.id):
+                continue
+
+            if self._is_pair_expired(entry):
+                continue
+
+            if self.is_soft_deleted(entry):
+                continue
+
+            result.append(
+                replace(
+                    entry,
+                    response=replace(entry.response, stream=self._stream_from_cache(entry.id)),
+                )
+            )
+
+        return result
+
+    def update_entry(
+        self,
+        id: UUID,  # noqa: A002
+        new_entry: Entry | Callable[[Entry], Entry],
+    ) -> Entry | None:
+        entry_key = f"hishel:entry:{id.hex}"
+        data = self._client.get(entry_key)
+        if data is None:
+            return None
+
+        existing = unpack(cast(bytes, data), kind="pair")
+
+        updated = new_entry(existing) if callable(new_entry) else new_entry
+
+        if existing.id != updated.id:
+            raise ValueError("Entry ID mismatch")
+
+        pttl = cast(int, self._client.pttl(entry_key))
+        packed = pack(updated, kind="pair")
+        if pttl > 0:
+            self._client.set(entry_key, packed, px=pttl)
+        else:
+            self._client.set(entry_key, packed)
+
+        if existing.cache_key != updated.cache_key:
+            old_key = existing.cache_key.decode() if isinstance(existing.cache_key, bytes) else existing.cache_key
+            new_key = updated.cache_key.decode() if isinstance(updated.cache_key, bytes) else updated.cache_key
+            self._client.srem(f"hishel:idx:{old_key}", id.hex)  # type: ignore[misc]
+            self._client.sadd(f"hishel:idx:{new_key}", id.hex)  # type: ignore[misc]
+
+        return updated
+
+    def remove_entry(self, id: UUID) -> None:  # noqa: A002
+        entry_key = f"hishel:entry:{id.hex}"
+        stream_key = f"hishel:stream:{id.hex}"
+        done_key = f"hishel:stream_done:{id.hex}"
+        with contextlib.suppress(RedisError):
+            # don't let deletes prevent reads; failures are non-fatal
+            self._client.delete(entry_key, stream_key, done_key)
+
+    def close(self) -> None:
+        self._client.close()

--- a/src/hishel/_core/_storages/_sync_redis.py
+++ b/src/hishel/_core/_storages/_sync_redis.py
@@ -150,12 +150,27 @@ try:
             if existing.id != updated.id:
                 raise ValueError("Entry ID mismatch")
 
-            pttl = cast(int, self._client.pttl(entry_key))
             packed = pack(updated, kind="pair")
-            if pttl > 0:
-                self._client.set(entry_key, packed, px=pttl)
+
+            if updated.meta.created_at != existing.meta.created_at:
+                # TTL refresh: reset all keys to the full original TTL
+                ttl = self._effective_ttl(updated.request)
+                if ttl is not None:
+                    pttl_ms = int(ttl * 1000)
+                    stream_key = f"{self._key_prefix}:stream:{id.hex}"
+                    done_key = f"{self._key_prefix}:stream_done:{id.hex}"
+                    self._client.set(entry_key, packed, px=pttl_ms)
+                    cast(int, self._client.pexpire(stream_key, pttl_ms))
+                    cast(int, self._client.pexpire(done_key, pttl_ms))
+                else:
+                    self._client.set(entry_key, packed)
             else:
-                self._client.set(entry_key, packed)
+                # Regular update: preserve remaining TTL
+                pttl = cast(int, self._client.pttl(entry_key))
+                if pttl > 0:
+                    self._client.set(entry_key, packed, px=pttl)
+                else:
+                    self._client.set(entry_key, packed)
 
             if existing.cache_key != updated.cache_key:
                 old_key = existing.cache_key.decode() if isinstance(existing.cache_key, bytes) else existing.cache_key

--- a/src/hishel/_core/_storages/_sync_redis.py
+++ b/src/hishel/_core/_storages/_sync_redis.py
@@ -54,13 +54,13 @@ try:
             idx_key = f"{self._key_prefix}:idx:{key}"
 
             if ttl is not None:
-                self._client.set(entry_key, packed, ex=int(ttl))
+                self._client.set(entry_key, packed, px=int(ttl * 1000))
             else:
                 self._client.set(entry_key, packed)
 
             cast(int, self._client.sadd(idx_key, pair_id.hex))
             if ttl is not None:
-                self._client.expire(idx_key, int(ttl))
+                cast(int, self._client.pexpire(idx_key, int(ttl * 1000)))
 
             return entry
 
@@ -78,8 +78,8 @@ try:
             cast(int, self._client.rpush(stream_key, b""))
             self._client.set(done_key, b"1")
             if ttl is not None:
-                self._client.expire(stream_key, int(ttl))
-                self._client.expire(done_key, int(ttl))
+                cast(int, self._client.pexpire(stream_key, int(ttl * 1000)))
+                cast(int, self._client.pexpire(done_key, int(ttl * 1000)))
 
         def _is_stream_complete(self, entry_id: UUID) -> bool:
             result = self._client.exists(f"{self._key_prefix}:stream_done:{entry_id.hex}")

--- a/src/hishel/_core/_storages/_sync_redis.py
+++ b/src/hishel/_core/_storages/_sync_redis.py
@@ -4,165 +4,176 @@ import contextlib
 from collections.abc import Iterator, Awaitable, Callable
 from dataclasses import replace
 from time import time
-from typing import cast
+from typing import Any, cast
 from uuid import UUID, uuid4
-
-from redis import RedisError
-from redis import Redis
 
 from hishel._core._storages._sync_base import SyncBaseStorage
 from hishel._core._storages._packing import pack, unpack
 from hishel._core.models import Entry, EntryMeta, Request, Response
 
+try:
+    from redis import RedisError
+    from redis import Redis
 
-class RedisStorage(SyncBaseStorage):
-    def __init__(self, client: Redis, ttl: int | float | None = None, key_prefix: str = "hishel") -> None:
-        self._client = client
-        self._default_ttl = ttl
-        self._key_prefix = key_prefix
+    class RedisStorage(SyncBaseStorage):
+        def __init__(self, client: Redis, ttl: int | float | None = None, key_prefix: str = "hishel") -> None:
+            self._client = client
+            self._default_ttl = ttl
+            self._key_prefix = key_prefix
 
-    def _effective_ttl(self, request: Request) -> int | float | None:
-        return request.metadata.get("hishel_ttl", self._default_ttl)
+        def _effective_ttl(self, request: Request) -> int | float | None:
+            return request.metadata.get("hishel_ttl", self._default_ttl)
 
-    def create_entry(self, request: Request, response: Response, key: str, id_: UUID | None = None) -> Entry:
-        pair_id = id_ or uuid4()
-        key_bytes = key.encode()
-        ttl = self._effective_ttl(request)
+        def create_entry(self, request: Request, response: Response, key: str, id_: UUID | None = None) -> Entry:
+            pair_id = id_ or uuid4()
+            key_bytes = key.encode()
+            ttl = self._effective_ttl(request)
 
-        response_with_stream = replace(
-            response,
-            stream=self._save_stream(cast(Iterator[bytes], response.stream), pair_id, ttl),
-        )
-
-        entry = Entry(
-            id=pair_id,
-            request=request,
-            response=response_with_stream,
-            meta=EntryMeta(created_at=time()),
-            cache_key=key_bytes,
-        )
-
-        packed = pack(entry, kind="pair")
-        entry_key = f"{self._key_prefix}:entry:{pair_id.hex}"
-        idx_key = f"{self._key_prefix}:idx:{key}"
-
-        if ttl is not None:
-            self._client.set(entry_key, packed, ex=int(ttl))
-        else:
-            self._client.set(entry_key, packed)
-
-        cast(int, self._client.sadd(idx_key, pair_id.hex))
-        if ttl is not None:
-            self._client.expire(idx_key, int(ttl))
-
-        return entry
-
-    def _save_stream(self, stream: Iterator[bytes], pair_id: UUID, ttl: int | float | None) -> Iterator[bytes]:
-        stream_key = f"{self._key_prefix}:stream:{pair_id.hex}"
-        done_key = f"{self._key_prefix}:stream_done:{pair_id.hex}"
-
-        for chunk in stream:
-            cast(int, self._client.rpush(stream_key, chunk))
-            yield chunk
-
-        # sentinel to mark end of stream
-        cast(int, self._client.rpush(stream_key, b""))
-        self._client.set(done_key, b"1")
-        if ttl is not None:
-            self._client.expire(stream_key, int(ttl))
-            self._client.expire(done_key, int(ttl))
-
-    def _is_stream_complete(self, entry_id: UUID) -> bool:
-        result = self._client.exists(f"{self._key_prefix}:stream_done:{entry_id.hex}")
-        return bool(result)
-
-    def _is_pair_expired(self, pair: Entry) -> bool:
-        ttl = self._effective_ttl(pair.request)
-        return ttl is not None and pair.meta.created_at + ttl < time()
-
-    def _stream_from_cache(self, entry_id: UUID) -> Iterator[bytes]:
-        stream_key = f"{self._key_prefix}:stream:{entry_id.hex}"
-        length = cast(int, self._client.llen(stream_key))
-        for i in range(length - 1):  # -1 excludes the sentinel
-            chunk = cast(bytes | None, self._client.lindex(stream_key, i))
-            if chunk is not None:
-                yield chunk.encode() if isinstance(chunk, str) else chunk
-
-    def get_entries(self, key: str) -> list[Entry]:
-        idx_key = f"{self._key_prefix}:idx:{key}"
-        members = cast(set[bytes], self._client.smembers(idx_key))
-
-        result: list[Entry] = []
-        for member in members:
-            hex_str = member.decode() if isinstance(member, bytes) else member
-            entry_key = f"{self._key_prefix}:entry:{hex_str}"
-
-            data = self._client.get(entry_key)
-            if data is None:
-                cast(int, self._client.srem(idx_key, member))
-                continue
-
-            entry = unpack(cast(bytes, data), kind="pair")
-            if entry is None:
-                continue
-
-            if not self._is_stream_complete(entry.id):
-                continue
-
-            if self._is_pair_expired(entry):
-                continue
-
-            if self.is_soft_deleted(entry):
-                continue
-
-            result.append(
-                replace(
-                    entry,
-                    response=replace(entry.response, stream=self._stream_from_cache(entry.id)),
-                )
+            response_with_stream = replace(
+                response,
+                stream=self._save_stream(cast(Iterator[bytes], response.stream), pair_id, ttl),
             )
 
-        return result
+            entry = Entry(
+                id=pair_id,
+                request=request,
+                response=response_with_stream,
+                meta=EntryMeta(created_at=time()),
+                cache_key=key_bytes,
+            )
 
-    def update_entry(
-        self,
-        id: UUID,  # noqa: A002
-        new_entry: Entry | Callable[[Entry], Entry],
-    ) -> Entry | None:
-        entry_key = f"{self._key_prefix}:entry:{id.hex}"
-        data = self._client.get(entry_key)
-        if data is None:
-            return None
+            packed = pack(entry, kind="pair")
+            entry_key = f"{self._key_prefix}:entry:{pair_id.hex}"
+            idx_key = f"{self._key_prefix}:idx:{key}"
 
-        existing = unpack(cast(bytes, data), kind="pair")
+            if ttl is not None:
+                self._client.set(entry_key, packed, ex=int(ttl))
+            else:
+                self._client.set(entry_key, packed)
 
-        updated = new_entry(existing) if callable(new_entry) else new_entry
+            cast(int, self._client.sadd(idx_key, pair_id.hex))
+            if ttl is not None:
+                self._client.expire(idx_key, int(ttl))
 
-        if existing.id != updated.id:
-            raise ValueError("Entry ID mismatch")
+            return entry
 
-        pttl = cast(int, self._client.pttl(entry_key))
-        packed = pack(updated, kind="pair")
-        if pttl > 0:
-            self._client.set(entry_key, packed, px=pttl)
-        else:
-            self._client.set(entry_key, packed)
+        def _save_stream(
+            self, stream: Iterator[bytes], pair_id: UUID, ttl: int | float | None
+        ) -> Iterator[bytes]:
+            stream_key = f"{self._key_prefix}:stream:{pair_id.hex}"
+            done_key = f"{self._key_prefix}:stream_done:{pair_id.hex}"
 
-        if existing.cache_key != updated.cache_key:
-            old_key = existing.cache_key.decode() if isinstance(existing.cache_key, bytes) else existing.cache_key
-            new_key = updated.cache_key.decode() if isinstance(updated.cache_key, bytes) else updated.cache_key
-            cast(int, self._client.srem(f"{self._key_prefix}:idx:{old_key}", id.hex))
-            cast(int, self._client.sadd(f"{self._key_prefix}:idx:{new_key}", id.hex))
+            for chunk in stream:
+                cast(int, self._client.rpush(stream_key, chunk))
+                yield chunk
 
-        return updated
+            # sentinel to mark end of stream
+            cast(int, self._client.rpush(stream_key, b""))
+            self._client.set(done_key, b"1")
+            if ttl is not None:
+                self._client.expire(stream_key, int(ttl))
+                self._client.expire(done_key, int(ttl))
 
-    def remove_entry(self, id: UUID) -> None:  # noqa: A002
-        entry_key = f"{self._key_prefix}:entry:{id.hex}"
-        stream_key = f"{self._key_prefix}:stream:{id.hex}"
-        done_key = f"{self._key_prefix}:stream_done:{id.hex}"
-        with contextlib.suppress(RedisError):
-            # don't let deletes prevent reads; failures are non-fatal
-            self._client.delete(entry_key, stream_key, done_key)
+        def _is_stream_complete(self, entry_id: UUID) -> bool:
+            result = self._client.exists(f"{self._key_prefix}:stream_done:{entry_id.hex}")
+            return bool(result)
 
-    def close(self) -> None:
-        self._client.close()
+        def _is_pair_expired(self, pair: Entry) -> bool:
+            ttl = self._effective_ttl(pair.request)
+            return ttl is not None and pair.meta.created_at + ttl < time()
+
+        def _stream_from_cache(self, entry_id: UUID) -> Iterator[bytes]:
+            stream_key = f"{self._key_prefix}:stream:{entry_id.hex}"
+            length = cast(int, self._client.llen(stream_key))
+            for i in range(length - 1):  # -1 excludes the sentinel
+                chunk = cast(bytes | None, self._client.lindex(stream_key, i))
+                if chunk is not None:
+                    yield chunk.encode() if isinstance(chunk, str) else chunk
+
+        def get_entries(self, key: str) -> list[Entry]:
+            idx_key = f"{self._key_prefix}:idx:{key}"
+            members = cast(set[bytes], self._client.smembers(idx_key))
+
+            result: list[Entry] = []
+            for member in members:
+                hex_str = member.decode() if isinstance(member, bytes) else member
+                entry_key = f"{self._key_prefix}:entry:{hex_str}"
+
+                data = self._client.get(entry_key)
+                if data is None:
+                    cast(int, self._client.srem(idx_key, member))
+                    continue
+
+                entry = unpack(cast(bytes, data), kind="pair")
+                if entry is None:
+                    continue
+
+                if not self._is_stream_complete(entry.id):
+                    continue
+
+                if self._is_pair_expired(entry):
+                    continue
+
+                if self.is_soft_deleted(entry):
+                    continue
+
+                result.append(
+                    replace(
+                        entry,
+                        response=replace(entry.response, stream=self._stream_from_cache(entry.id)),
+                    )
+                )
+
+            return result
+
+        def update_entry(
+            self,
+            id: UUID,  # noqa: A002
+            new_entry: Entry | Callable[[Entry], Entry],
+        ) -> Entry | None:
+            entry_key = f"{self._key_prefix}:entry:{id.hex}"
+            data = self._client.get(entry_key)
+            if data is None:
+                return None
+
+            existing = unpack(cast(bytes, data), kind="pair")
+
+            updated = new_entry(existing) if callable(new_entry) else new_entry
+
+            if existing.id != updated.id:
+                raise ValueError("Entry ID mismatch")
+
+            pttl = cast(int, self._client.pttl(entry_key))
+            packed = pack(updated, kind="pair")
+            if pttl > 0:
+                self._client.set(entry_key, packed, px=pttl)
+            else:
+                self._client.set(entry_key, packed)
+
+            if existing.cache_key != updated.cache_key:
+                old_key = existing.cache_key.decode() if isinstance(existing.cache_key, bytes) else existing.cache_key
+                new_key = updated.cache_key.decode() if isinstance(updated.cache_key, bytes) else updated.cache_key
+                cast(int, self._client.srem(f"{self._key_prefix}:idx:{old_key}", id.hex))
+                cast(int, self._client.sadd(f"{self._key_prefix}:idx:{new_key}", id.hex))
+
+            return updated
+
+        def remove_entry(self, id: UUID) -> None:  # noqa: A002
+            entry_key = f"{self._key_prefix}:entry:{id.hex}"
+            stream_key = f"{self._key_prefix}:stream:{id.hex}"
+            done_key = f"{self._key_prefix}:stream_done:{id.hex}"
+            with contextlib.suppress(RedisError):
+                # don't let deletes prevent reads; failures are non-fatal
+                self._client.delete(entry_key, stream_key, done_key)
+
+        def close(self) -> None:
+            self._client.close()
+
+except ImportError:
+
+    class RedisStorage:  # type: ignore[no-redef]
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            raise ImportError(
+                "The 'redis' library is required to use the `RedisStorage` integration. "
+                "Install hishel with 'pip install hishel[redis]'."
+            )

--- a/src/hishel/_core/_storages/_sync_redis.py
+++ b/src/hishel/_core/_storages/_sync_redis.py
@@ -16,10 +16,17 @@ try:
     from redis import Redis
 
     class RedisStorage(SyncBaseStorage):
-        def __init__(self, client: Redis, ttl: int | float | None = None, key_prefix: str = "hishel") -> None:
+        def __init__(
+            self,
+            client: Redis,
+            ttl: int | float | None = None,
+            key_prefix: str = "hishel",
+            soft_delete_ttl: int = 180,
+        ) -> None:
             self._client = client
             self._default_ttl = ttl
             self._key_prefix = key_prefix
+            self._soft_delete_ttl = soft_delete_ttl
 
         def _effective_ttl(self, request: Request) -> int | float | None:
             return request.metadata.get("hishel_ttl", self._default_ttl)
@@ -163,8 +170,17 @@ try:
             stream_key = f"{self._key_prefix}:stream:{id.hex}"
             done_key = f"{self._key_prefix}:stream_done:{id.hex}"
             with contextlib.suppress(RedisError):
-                # don't let deletes prevent reads; failures are non-fatal
-                self._client.delete(entry_key, stream_key, done_key)
+                data = self._client.get(entry_key)
+                if data is None:
+                    return
+                entry = unpack(cast(bytes, data), kind="pair")
+                if entry is None:
+                    return
+                updated = self.mark_pair_as_deleted(entry)
+                packed = pack(updated, kind="pair")
+                self._client.set(entry_key, packed, ex=self._soft_delete_ttl)
+                self._client.expire(stream_key, self._soft_delete_ttl)
+                self._client.expire(done_key, self._soft_delete_ttl)
 
         def close(self) -> None:
             self._client.close()

--- a/src/hishel/_core/_storages/_sync_redis.py
+++ b/src/hishel/_core/_storages/_sync_redis.py
@@ -21,13 +21,17 @@ class RedisStorage(SyncBaseStorage):
         self._default_ttl = ttl
         self._key_prefix = key_prefix
 
+    def _effective_ttl(self, request: Request) -> int | float | None:
+        return request.metadata.get("hishel_ttl", self._default_ttl)
+
     def create_entry(self, request: Request, response: Response, key: str, id_: UUID | None = None) -> Entry:
         pair_id = id_ or uuid4()
         key_bytes = key.encode()
+        ttl = self._effective_ttl(request)
 
         response_with_stream = replace(
             response,
-            stream=self._save_stream(cast(Iterator[bytes], response.stream), pair_id),
+            stream=self._save_stream(cast(Iterator[bytes], response.stream), pair_id, ttl),
         )
 
         entry = Entry(
@@ -42,18 +46,18 @@ class RedisStorage(SyncBaseStorage):
         entry_key = f"{self._key_prefix}:entry:{pair_id.hex}"
         idx_key = f"{self._key_prefix}:idx:{key}"
 
-        if self._default_ttl is not None:
-            self._client.set(entry_key, packed, ex=int(self._default_ttl))
+        if ttl is not None:
+            self._client.set(entry_key, packed, ex=int(ttl))
         else:
             self._client.set(entry_key, packed)
 
         cast(int, self._client.sadd(idx_key, pair_id.hex))
-        if self._default_ttl is not None:
-            self._client.expire(idx_key, int(self._default_ttl))
+        if ttl is not None:
+            self._client.expire(idx_key, int(ttl))
 
         return entry
 
-    def _save_stream(self, stream: Iterator[bytes], pair_id: UUID) -> Iterator[bytes]:
+    def _save_stream(self, stream: Iterator[bytes], pair_id: UUID, ttl: int | float | None) -> Iterator[bytes]:
         stream_key = f"{self._key_prefix}:stream:{pair_id.hex}"
         done_key = f"{self._key_prefix}:stream_done:{pair_id.hex}"
 
@@ -64,16 +68,16 @@ class RedisStorage(SyncBaseStorage):
         # sentinel to mark end of stream
         cast(int, self._client.rpush(stream_key, b""))
         self._client.set(done_key, b"1")
-        if self._default_ttl is not None:
-            self._client.expire(stream_key, int(self._default_ttl))
-            self._client.expire(done_key, int(self._default_ttl))
+        if ttl is not None:
+            self._client.expire(stream_key, int(ttl))
+            self._client.expire(done_key, int(ttl))
 
     def _is_stream_complete(self, entry_id: UUID) -> bool:
         result = self._client.exists(f"{self._key_prefix}:stream_done:{entry_id.hex}")
         return bool(result)
 
     def _is_pair_expired(self, pair: Entry) -> bool:
-        ttl = pair.request.metadata.get("hishel_ttl", self._default_ttl)
+        ttl = self._effective_ttl(pair.request)
         return ttl is not None and pair.meta.created_at + ttl < time()
 
     def _stream_from_cache(self, entry_id: UUID) -> Iterator[bytes]:

--- a/tests/_core/_async/test_redis_storage.py
+++ b/tests/_core/_async/test_redis_storage.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import replace
+from datetime import datetime
+from typing import AsyncIterator
+from unittest.mock import AsyncMock
+from zoneinfo import ZoneInfo
+
+import fakeredis.aioredis
+import pytest
+from time_machine import travel
+
+from hishel import Request, Response
+from hishel._core._storages._async_redis import AsyncRedisStorage
+from hishel._utils import make_async_iterator
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    # redis.asyncio is asyncio-only; restrict async tests to asyncio backend
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_add_entry() -> None:
+    """Test adding a complete entry with request and response."""
+    client = fakeredis.aioredis.FakeRedis()
+    storage = AsyncRedisStorage(client=client)
+
+    entry = await storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_async_iterator([b"response data"])),
+        key="test_key",
+        id_=uuid.UUID(int=0),
+    )
+
+    async for _ in entry.response._aiter_stream():
+        ...
+
+    entries = await storage.get_entries("test_key")
+    assert len(entries) == 1
+    assert entries[0].cache_key == b"test_key"
+
+
+@pytest.mark.anyio
+async def test_add_entry_with_stream() -> None:
+    """Test adding an entry with a multi-chunk streaming response body."""
+    client = fakeredis.aioredis.FakeRedis()
+    storage = AsyncRedisStorage(client=client)
+
+    entry = await storage.create_entry(
+        request=Request(method="POST", url="https://example.com/upload"),
+        response=Response(status_code=200, stream=make_async_iterator([b"chunk1", b"chunk2"])),
+        key="stream_key",
+        id_=uuid.UUID(int=0),
+    )
+
+    async for _ in entry.response._aiter_stream():
+        ...
+
+    entries = await storage.get_entries("stream_key")
+    assert len(entries) == 1
+    assert entries[0].cache_key == b"stream_key"
+
+
+@pytest.mark.anyio
+async def test_get_entries() -> None:
+    """Test retrieving entries by cache key."""
+    client = fakeredis.aioredis.FakeRedis()
+    storage = AsyncRedisStorage(client=client)
+
+    e1 = await storage.create_entry(
+        request=Request(method="GET", url="https://example.com/1"),
+        response=Response(status_code=200, stream=make_async_iterator([b"response1"])),
+        key="shared_key",
+        id_=uuid.UUID(int=1),
+    )
+    await e1.response.aread()
+
+    e2 = await storage.create_entry(
+        request=Request(method="GET", url="https://example.com/2"),
+        response=Response(status_code=200, stream=make_async_iterator([b"response2"])),
+        key="shared_key",
+        id_=uuid.UUID(int=2),
+    )
+    await e2.response.aread()
+
+    entries = await storage.get_entries("shared_key")
+    assert len(entries) == 2
+    assert all(entry.cache_key == b"shared_key" for entry in entries)
+
+
+@pytest.mark.anyio
+async def test_multiple_entries_same_key() -> None:
+    """Test creating multiple entries with the same cache key."""
+    client = fakeredis.aioredis.FakeRedis()
+    storage = AsyncRedisStorage(client=client)
+
+    e1 = await storage.create_entry(
+        request=Request(method="GET", url="https://example.com/1"),
+        response=Response(status_code=200, stream=make_async_iterator([b"response1"])),
+        key="shared_key",
+        id_=uuid.UUID(int=3),
+    )
+    await e1.response.aread()
+
+    e2 = await storage.create_entry(
+        request=Request(method="GET", url="https://example.com/2"),
+        response=Response(status_code=200, stream=make_async_iterator([b"response2"])),
+        key="shared_key",
+        id_=uuid.UUID(int=4),
+    )
+    await e2.response.aread()
+
+    entries = await storage.get_entries("shared_key")
+    assert len(entries) == 2
+    assert all(entry.response is not None for entry in entries)
+
+
+@pytest.mark.anyio
+async def test_multiple_entries_different_keys() -> None:
+    """Test that entries with different keys are properly isolated."""
+    client = fakeredis.aioredis.FakeRedis()
+    storage = AsyncRedisStorage(client=client)
+
+    for i in range(3):
+        entry = await storage.create_entry(
+            request=Request(method="GET", url=f"https://example.com/{i}"),
+            response=Response(status_code=200, stream=make_async_iterator([f"data{i}".encode()])),
+            key=f"key_{i}",
+            id_=uuid.UUID(int=9 + i),
+        )
+        async for _ in entry.response._aiter_stream():
+            ...
+
+    for i in range(3):
+        entries = await storage.get_entries(f"key_{i}")
+        assert len(entries) == 1
+        assert entries[0].request.url == f"https://example.com/{i}"
+
+
+@pytest.mark.anyio
+async def test_update_entry() -> None:
+    """Test updating an existing entry with a callable."""
+    client = fakeredis.aioredis.FakeRedis()
+    storage = AsyncRedisStorage(client=client)
+
+    entry = await storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_async_iterator([b"original"])),
+        key="original_key",
+        id_=uuid.UUID(int=5),
+    )
+    await entry.response.aread()
+
+    def updater(pair):
+        return replace(pair, cache_key=b"updated_key")
+
+    result = await storage.update_entry(entry.id, updater)
+    assert result is not None
+    assert result.cache_key == b"updated_key"
+
+    entries = await storage.get_entries("updated_key")
+    assert len(entries) == 1
+    assert entries[0].cache_key == b"updated_key"
+
+
+@pytest.mark.anyio
+async def test_update_entry_with_new_entry() -> None:
+    """Test updating an entry by providing a new entry directly."""
+    client = fakeredis.aioredis.FakeRedis()
+    storage = AsyncRedisStorage(client=client)
+
+    entry = await storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_async_iterator([b"data"])),
+        key="key1",
+        id_=uuid.UUID(int=6),
+    )
+    await entry.response.aread()
+
+    new_entry = replace(entry, cache_key=b"key2")
+    result = await storage.update_entry(entry.id, new_entry)
+
+    assert result is not None
+    assert result.cache_key == b"key2"
+
+
+@pytest.mark.anyio
+async def test_remove_entry() -> None:
+    """Test that remove_entry hard-deletes all Redis keys for the entry."""
+    client = fakeredis.aioredis.FakeRedis()
+    storage = AsyncRedisStorage(client=client)
+
+    entry = await storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_async_iterator([b"data"])),
+        key="test_key",
+        id_=uuid.UUID(int=7),
+    )
+    await entry.response.aread()
+
+    await storage.remove_entry(entry.id)
+
+    hex_id = entry.id.hex
+    assert await client.exists(f"hishel:entry:{hex_id}") == 0
+    assert await client.exists(f"hishel:stream:{hex_id}") == 0
+    assert await client.exists(f"hishel:stream_done:{hex_id}") == 0
+
+
+@pytest.mark.anyio
+async def test_stream_persistence() -> None:
+    """Test that streams are properly saved and retrieved."""
+    client = fakeredis.aioredis.FakeRedis()
+    storage = AsyncRedisStorage(client=client)
+
+    response_chunks = [b"resp1", b"resp2"]
+
+    entry = await storage.create_entry(
+        request=Request(method="POST", url="https://example.com"),
+        response=Response(status_code=200, stream=make_async_iterator(response_chunks)),
+        key="stream_test",
+        id_=uuid.UUID(int=8),
+    )
+
+    async for _ in entry.response._aiter_stream():
+        ...
+
+    entries = await storage.get_entries("stream_test")
+    assert len(entries) == 1
+
+    retrieved_chunks = []
+    async for chunk in entries[0].response._aiter_stream():
+        retrieved_chunks.append(chunk)
+
+    assert retrieved_chunks == response_chunks
+
+
+@pytest.mark.anyio
+async def test_remove_nonexistent_entry() -> None:
+    """Test that removing a non-existent entry doesn't raise an error."""
+    client = fakeredis.aioredis.FakeRedis()
+    storage = AsyncRedisStorage(client=client)
+
+    await storage.remove_entry(uuid.UUID(int=999))
+
+
+@pytest.mark.anyio
+async def test_update_nonexistent_entry() -> None:
+    """Test that updating a non-existent entry returns None."""
+    client = fakeredis.aioredis.FakeRedis()
+    storage = AsyncRedisStorage(client=client)
+
+    result = await storage.update_entry(uuid.UUID(int=999), lambda p: replace(p, cache_key=b"new_key"))
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_close_connection() -> None:
+    """Test that close() calls aclose() on the underlying async Redis client."""
+    mock_client = AsyncMock()
+    mock_client.aclose = AsyncMock()
+    storage = AsyncRedisStorage(client=mock_client)
+
+    await storage.close()
+
+    mock_client.aclose.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_incomplete_entries() -> None:
+    """Test that entries with an incomplete stream are excluded from get_entries."""
+    client = fakeredis.aioredis.FakeRedis()
+    storage = AsyncRedisStorage(client=client)
+
+    entry = await storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_async_iterator([b"chunk1", b"chunk2"])),
+        key="incomplete_key",
+        id_=uuid.UUID(int=10),
+    )
+
+    assert isinstance(entry.response.stream, AsyncIterator)
+    await entry.response.stream.__anext__()
+
+    entries = await storage.get_entries("incomplete_key")
+    assert len(entries) == 0
+
+
+@pytest.mark.anyio
+async def test_expired_entries() -> None:
+    """Test that entries past their TTL are excluded from get_entries."""
+    client = fakeredis.aioredis.FakeRedis()
+    # ttl=3600 (1h): large enough that fakeredis won't expire the key during the test,
+    # but time_machine advances frozen time by 2h so the Python-level check triggers expiry.
+    storage = AsyncRedisStorage(client=client, ttl=3600)
+
+    with travel(datetime(2024, 1, 1, 0, 0, 0, tzinfo=ZoneInfo("UTC"))):
+        entry = await storage.create_entry(
+            request=Request(method="GET", url="https://example.com"),
+            response=Response(status_code=200, stream=make_async_iterator([b"data"])),
+            key="expired_key",
+            id_=uuid.UUID(int=11),
+        )
+        await entry.response.aread()
+
+    with travel(datetime(2024, 1, 1, 2, 0, 0, tzinfo=ZoneInfo("UTC"))):
+        entries = await storage.get_entries("expired_key")
+        assert len(entries) == 0
+
+
+@pytest.mark.anyio
+async def test_soft_deleted_entries() -> None:
+    """Test that entries marked as soft-deleted are excluded from get_entries."""
+    client = fakeredis.aioredis.FakeRedis()
+    storage = AsyncRedisStorage(client=client)
+
+    entry = await storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_async_iterator([b"data"])),
+        key="soft_deleted_key",
+        id_=uuid.UUID(int=12),
+    )
+    await entry.response.aread()
+
+    await storage.update_entry(entry.id, storage.mark_pair_as_deleted)
+
+    entries = await storage.get_entries("soft_deleted_key")
+    assert len(entries) == 0
+
+
+@pytest.mark.anyio
+async def test_custom_ttl() -> None:
+    """Test that hishel_ttl in request metadata overrides default_ttl for expiry checks."""
+    client = fakeredis.aioredis.FakeRedis()
+    # storage.ttl=3600 sets Redis TTL (key alive for 1h) and default Python TTL.
+    # hishel_ttl=1 overrides the Python check to expire the entry sooner.
+    storage = AsyncRedisStorage(client=client, ttl=3600)
+
+    with travel(datetime(2024, 1, 1, 0, 0, 0, tzinfo=ZoneInfo("UTC"))):
+        entry = await storage.create_entry(
+            request=Request(method="GET", url="https://example.com", metadata={"hishel_ttl": 1}),
+            response=Response(status_code=200, stream=make_async_iterator([b"data"])),
+            key="test_key",
+            id_=uuid.UUID(int=13),
+        )
+        await entry.response.aread()
+
+    with travel(datetime(2024, 1, 1, 0, 0, 2, tzinfo=ZoneInfo("UTC"))):
+        entries = await storage.get_entries("test_key")
+        assert len(entries) == 0

--- a/tests/_core/_async/test_redis_storage.py
+++ b/tests/_core/_async/test_redis_storage.py
@@ -350,3 +350,26 @@ async def test_custom_ttl() -> None:
     with travel(datetime(2024, 1, 1, 0, 0, 2, tzinfo=ZoneInfo("UTC"))):
         entries = await storage.get_entries("test_key")
         assert len(entries) == 0
+
+
+@pytest.mark.anyio
+async def test_custom_prefix() -> None:
+    """Test checking custom redis key prefix."""
+    client = fakeredis.aioredis.FakeRedis()
+    key_prefix = "a_key_prefix"
+    storage = AsyncRedisStorage(client=client, key_prefix=key_prefix)
+
+    entry = await storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_async_iterator([b"response data"])),
+        key="test_key",
+        id_=uuid.UUID(int=0),
+    )
+
+    async for _ in entry.response._aiter_stream():
+        ...
+
+    hex_id = entry.id.hex
+    assert await client.exists(f"{key_prefix}:entry:{hex_id}") == 1
+    assert await client.exists(f"{key_prefix}:stream:{hex_id}") == 1
+    assert await client.exists(f"{key_prefix}:stream_done:{hex_id}") == 1

--- a/tests/_core/_async/test_redis_storage.py
+++ b/tests/_core/_async/test_redis_storage.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from dataclasses import replace
 from datetime import datetime
-from typing import AsyncIterator
+from typing import AsyncIterator, Awaitable, cast
 from unittest.mock import AsyncMock
 from zoneinfo import ZoneInfo
 
@@ -189,7 +189,7 @@ async def test_update_entry_with_new_entry() -> None:
 
 @pytest.mark.anyio
 async def test_remove_entry() -> None:
-    """Test that remove_entry hard-deletes all Redis keys for the entry."""
+    """Test that remove_entry soft-deletes the entry and hides it from get_entries."""
     client = fakeredis.aioredis.FakeRedis()
     storage = AsyncRedisStorage(client=client)
 
@@ -204,9 +204,32 @@ async def test_remove_entry() -> None:
     await storage.remove_entry(entry.id)
 
     hex_id = entry.id.hex
-    assert await client.exists(f"hishel:entry:{hex_id}") == 0
-    assert await client.exists(f"hishel:stream:{hex_id}") == 0
-    assert await client.exists(f"hishel:stream_done:{hex_id}") == 0
+    # Keys still exist (soft delete, not hard delete)
+    assert await client.exists(f"hishel:entry:{hex_id}") == 1
+    # A TTL has been set on the entry key
+    assert 0 < await cast(Awaitable[int], client.ttl(f"hishel:entry:{hex_id}")) <= 180
+    # Soft-deleted entry is invisible to get_entries
+    assert await storage.get_entries("test_key") == []
+
+
+@pytest.mark.anyio
+async def test_remove_entry_custom_soft_delete_ttl() -> None:
+    """Test that a custom soft_delete_ttl is applied to Redis keys after remove_entry."""
+    client = fakeredis.aioredis.FakeRedis()
+    storage = AsyncRedisStorage(client=client, soft_delete_ttl=60)
+
+    entry = await storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_async_iterator([b"data"])),
+        key="test_key",
+        id_=uuid.UUID(int=70),
+    )
+    await entry.response.aread()
+
+    await storage.remove_entry(entry.id)
+
+    hex_id = entry.id.hex
+    assert 0 < await cast(Awaitable[int], client.ttl(f"hishel:entry:{hex_id}")) <= 60
 
 
 @pytest.mark.anyio

--- a/tests/_core/_async/test_redis_storage.py
+++ b/tests/_core/_async/test_redis_storage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 import uuid
 from dataclasses import replace
 from datetime import datetime
@@ -185,6 +186,31 @@ async def test_update_entry_with_new_entry() -> None:
 
     assert result is not None
     assert result.cache_key == b"key2"
+
+
+@pytest.mark.anyio
+async def test_refresh_ttl_on_access() -> None:
+    """Test that update_entry resets the Redis key TTL when created_at is refreshed."""
+    client = fakeredis.aioredis.FakeRedis()
+    storage = AsyncRedisStorage(client=client)
+
+    with travel(datetime(2024, 1, 1, 0, 0, 0, tzinfo=ZoneInfo("UTC"))):
+        entry = await storage.create_entry(
+            request=Request(method="GET", url="https://example.com", metadata={"hishel_ttl": 60}),
+            response=Response(status_code=200, stream=make_async_iterator([b"data"])),
+            key="test_key",
+            id_=uuid.UUID(int=15),
+        )
+        await entry.response.aread()
+
+    # Advance 30 s — half the TTL consumed, ~30 000 ms remaining
+    with travel(datetime(2024, 1, 1, 0, 0, 30, tzinfo=ZoneInfo("UTC"))):
+        await storage.update_entry(
+            entry.id,
+            lambda e: replace(e, meta=replace(e.meta, created_at=time.time())),
+        )
+        pttl = await cast(Awaitable[int], client.pttl(f"hishel:entry:{entry.id.hex}"))
+        assert pttl > 30_000  # reset to the full 60 s, not just the remaining ~30 s
 
 
 @pytest.mark.anyio

--- a/tests/_core/_async/test_redis_storage.py
+++ b/tests/_core/_async/test_redis_storage.py
@@ -390,9 +390,9 @@ async def test_hishel_ttl_sets_redis_key_expiry() -> None:
     await entry.response.aread()
 
     hex_id = entry.id.hex
-    entry_ttl = await client.ttl(f"hishel:entry:{hex_id}")
-    assert isinstance(entry_ttl, int)
-    assert 0 < entry_ttl <= 42
+    entry_pttl = await client.pttl(f"hishel:entry:{hex_id}")
+    assert isinstance(entry_pttl, int)
+    assert 0 < entry_pttl <= 42000
 
 
 @pytest.mark.anyio

--- a/tests/_core/_async/test_redis_storage.py
+++ b/tests/_core/_async/test_redis_storage.py
@@ -353,6 +353,25 @@ async def test_custom_ttl() -> None:
 
 
 @pytest.mark.anyio
+async def test_hishel_ttl_sets_redis_key_expiry() -> None:
+    """Test that hishel_ttl in request metadata sets the Redis key TTL, not just the Python-level check."""
+    client = fakeredis.aioredis.FakeRedis()
+    storage = AsyncRedisStorage(client=client)
+
+    entry = await storage.create_entry(
+        request=Request(method="GET", url="https://example.com", metadata={"hishel_ttl": 42}),
+        response=Response(status_code=200, stream=make_async_iterator([b"data"])),
+        key="test_key",
+        id_=uuid.UUID(int=14),
+    )
+    await entry.response.aread()
+
+    hex_id = entry.id.hex
+    entry_ttl = await client.ttl(f"hishel:entry:{hex_id}")
+    assert 0 < entry_ttl <= 42
+
+
+@pytest.mark.anyio
 async def test_custom_prefix() -> None:
     """Test checking custom redis key prefix."""
     client = fakeredis.aioredis.FakeRedis()

--- a/tests/_core/_async/test_redis_storage.py
+++ b/tests/_core/_async/test_redis_storage.py
@@ -368,6 +368,7 @@ async def test_hishel_ttl_sets_redis_key_expiry() -> None:
 
     hex_id = entry.id.hex
     entry_ttl = await client.ttl(f"hishel:entry:{hex_id}")
+    assert isinstance(entry_ttl, int)
     assert 0 < entry_ttl <= 42
 
 

--- a/tests/_core/_sync/test_redis_storage.py
+++ b/tests/_core/_sync/test_redis_storage.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import replace
+from datetime import datetime
+from typing import Iterator
+from unittest.mock import MagicMock
+from zoneinfo import ZoneInfo
+
+import fakeredis
+import pytest
+from time_machine import travel
+
+from hishel import Request, Response
+from hishel._core._storages._sync_redis import RedisStorage
+from hishel._utils import make_sync_iterator
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    # redis is asyncio-only; restrict async tests to asyncio backend
+    return "asyncio"
+
+
+
+def test_add_entry() -> None:
+    """Test adding a complete entry with request and response."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"response data"])),
+        key="test_key",
+        id_=uuid.UUID(int=0),
+    )
+
+    for _ in entry.response._iter_stream():
+        ...
+
+    entries = storage.get_entries("test_key")
+    assert len(entries) == 1
+    assert entries[0].cache_key == b"test_key"
+
+
+
+def test_add_entry_with_stream() -> None:
+    """Test adding an entry with a multi-chunk streaming response body."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    entry = storage.create_entry(
+        request=Request(method="POST", url="https://example.com/upload"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"chunk1", b"chunk2"])),
+        key="stream_key",
+        id_=uuid.UUID(int=0),
+    )
+
+    for _ in entry.response._iter_stream():
+        ...
+
+    entries = storage.get_entries("stream_key")
+    assert len(entries) == 1
+    assert entries[0].cache_key == b"stream_key"
+
+
+
+def test_get_entries() -> None:
+    """Test retrieving entries by cache key."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    e1 = storage.create_entry(
+        request=Request(method="GET", url="https://example.com/1"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"response1"])),
+        key="shared_key",
+        id_=uuid.UUID(int=1),
+    )
+    e1.response.read()
+
+    e2 = storage.create_entry(
+        request=Request(method="GET", url="https://example.com/2"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"response2"])),
+        key="shared_key",
+        id_=uuid.UUID(int=2),
+    )
+    e2.response.read()
+
+    entries = storage.get_entries("shared_key")
+    assert len(entries) == 2
+    assert all(entry.cache_key == b"shared_key" for entry in entries)
+
+
+
+def test_multiple_entries_same_key() -> None:
+    """Test creating multiple entries with the same cache key."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    e1 = storage.create_entry(
+        request=Request(method="GET", url="https://example.com/1"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"response1"])),
+        key="shared_key",
+        id_=uuid.UUID(int=3),
+    )
+    e1.response.read()
+
+    e2 = storage.create_entry(
+        request=Request(method="GET", url="https://example.com/2"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"response2"])),
+        key="shared_key",
+        id_=uuid.UUID(int=4),
+    )
+    e2.response.read()
+
+    entries = storage.get_entries("shared_key")
+    assert len(entries) == 2
+    assert all(entry.response is not None for entry in entries)
+
+
+
+def test_multiple_entries_different_keys() -> None:
+    """Test that entries with different keys are properly isolated."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    for i in range(3):
+        entry = storage.create_entry(
+            request=Request(method="GET", url=f"https://example.com/{i}"),
+            response=Response(status_code=200, stream=make_sync_iterator([f"data{i}".encode()])),
+            key=f"key_{i}",
+            id_=uuid.UUID(int=9 + i),
+        )
+        for _ in entry.response._iter_stream():
+            ...
+
+    for i in range(3):
+        entries = storage.get_entries(f"key_{i}")
+        assert len(entries) == 1
+        assert entries[0].request.url == f"https://example.com/{i}"
+
+
+
+def test_update_entry() -> None:
+    """Test updating an existing entry with a callable."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"original"])),
+        key="original_key",
+        id_=uuid.UUID(int=5),
+    )
+    entry.response.read()
+
+    def updater(pair):
+        return replace(pair, cache_key=b"updated_key")
+
+    result = storage.update_entry(entry.id, updater)
+    assert result is not None
+    assert result.cache_key == b"updated_key"
+
+    entries = storage.get_entries("updated_key")
+    assert len(entries) == 1
+    assert entries[0].cache_key == b"updated_key"
+
+
+
+def test_update_entry_with_new_entry() -> None:
+    """Test updating an entry by providing a new entry directly."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"data"])),
+        key="key1",
+        id_=uuid.UUID(int=6),
+    )
+    entry.response.read()
+
+    new_entry = replace(entry, cache_key=b"key2")
+    result = storage.update_entry(entry.id, new_entry)
+
+    assert result is not None
+    assert result.cache_key == b"key2"
+
+
+
+def test_remove_entry() -> None:
+    """Test that remove_entry hard-deletes all Redis keys for the entry."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"data"])),
+        key="test_key",
+        id_=uuid.UUID(int=7),
+    )
+    entry.response.read()
+
+    storage.remove_entry(entry.id)
+
+    hex_id = entry.id.hex
+    assert client.exists(f"hishel:entry:{hex_id}") == 0
+    assert client.exists(f"hishel:stream:{hex_id}") == 0
+    assert client.exists(f"hishel:stream_done:{hex_id}") == 0
+
+
+
+def test_stream_persistence() -> None:
+    """Test that streams are properly saved and retrieved."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    response_chunks = [b"resp1", b"resp2"]
+
+    entry = storage.create_entry(
+        request=Request(method="POST", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator(response_chunks)),
+        key="stream_test",
+        id_=uuid.UUID(int=8),
+    )
+
+    for _ in entry.response._iter_stream():
+        ...
+
+    entries = storage.get_entries("stream_test")
+    assert len(entries) == 1
+
+    retrieved_chunks = []
+    for chunk in entries[0].response._iter_stream():
+        retrieved_chunks.append(chunk)
+
+    assert retrieved_chunks == response_chunks
+
+
+
+def test_remove_nonexistent_entry() -> None:
+    """Test that removing a non-existent entry doesn't raise an error."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    storage.remove_entry(uuid.UUID(int=999))
+
+
+
+def test_update_nonexistent_entry() -> None:
+    """Test that updating a non-existent entry returns None."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    result = storage.update_entry(uuid.UUID(int=999), lambda p: replace(p, cache_key=b"new_key"))
+    assert result is None
+
+
+
+def test_close_connection() -> None:
+    """Test that close() calls close() on the underlying async Redis client."""
+    mock_client = MagicMock()
+    mock_client.close = MagicMock()
+    storage = RedisStorage(client=mock_client)
+
+    storage.close()
+
+    mock_client.close.assert_called_once()
+
+
+
+def test_incomplete_entries() -> None:
+    """Test that entries with an incomplete stream are excluded from get_entries."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"chunk1", b"chunk2"])),
+        key="incomplete_key",
+        id_=uuid.UUID(int=10),
+    )
+
+    assert isinstance(entry.response.stream, Iterator)
+    entry.response.stream.__next__()
+
+    entries = storage.get_entries("incomplete_key")
+    assert len(entries) == 0
+
+
+
+def test_expired_entries() -> None:
+    """Test that entries past their TTL are excluded from get_entries."""
+    client = fakeredis.FakeRedis()
+    # ttl=3600 (1h): large enough that fakeredis won't expire the key during the test,
+    # but time_machine advances frozen time by 2h so the Python-level check triggers expiry.
+    storage = RedisStorage(client=client, ttl=3600)
+
+    with travel(datetime(2024, 1, 1, 0, 0, 0, tzinfo=ZoneInfo("UTC"))):
+        entry = storage.create_entry(
+            request=Request(method="GET", url="https://example.com"),
+            response=Response(status_code=200, stream=make_sync_iterator([b"data"])),
+            key="expired_key",
+            id_=uuid.UUID(int=11),
+        )
+        entry.response.read()
+
+    with travel(datetime(2024, 1, 1, 2, 0, 0, tzinfo=ZoneInfo("UTC"))):
+        entries = storage.get_entries("expired_key")
+        assert len(entries) == 0
+
+
+
+def test_soft_deleted_entries() -> None:
+    """Test that entries marked as soft-deleted are excluded from get_entries."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"data"])),
+        key="soft_deleted_key",
+        id_=uuid.UUID(int=12),
+    )
+    entry.response.read()
+
+    storage.update_entry(entry.id, storage.mark_pair_as_deleted)
+
+    entries = storage.get_entries("soft_deleted_key")
+    assert len(entries) == 0
+
+
+
+def test_custom_ttl() -> None:
+    """Test that hishel_ttl in request metadata overrides default_ttl for expiry checks."""
+    client = fakeredis.FakeRedis()
+    # storage.ttl=3600 sets Redis TTL (key alive for 1h) and default Python TTL.
+    # hishel_ttl=1 overrides the Python check to expire the entry sooner.
+    storage = RedisStorage(client=client, ttl=3600)
+
+    with travel(datetime(2024, 1, 1, 0, 0, 0, tzinfo=ZoneInfo("UTC"))):
+        entry = storage.create_entry(
+            request=Request(method="GET", url="https://example.com", metadata={"hishel_ttl": 1}),
+            response=Response(status_code=200, stream=make_sync_iterator([b"data"])),
+            key="test_key",
+            id_=uuid.UUID(int=13),
+        )
+        entry.response.read()
+
+    with travel(datetime(2024, 1, 1, 0, 0, 2, tzinfo=ZoneInfo("UTC"))):
+        entries = storage.get_entries("test_key")
+        assert len(entries) == 0

--- a/tests/_core/_sync/test_redis_storage.py
+++ b/tests/_core/_sync/test_redis_storage.py
@@ -350,3 +350,26 @@ def test_custom_ttl() -> None:
     with travel(datetime(2024, 1, 1, 0, 0, 2, tzinfo=ZoneInfo("UTC"))):
         entries = storage.get_entries("test_key")
         assert len(entries) == 0
+
+
+
+def test_custom_prefix() -> None:
+    """Test checking custom redis key prefix."""
+    client = fakeredis.FakeRedis()
+    key_prefix = "a_key_prefix"
+    storage = RedisStorage(client=client, key_prefix=key_prefix)
+
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"response data"])),
+        key="test_key",
+        id_=uuid.UUID(int=0),
+    )
+
+    for _ in entry.response._iter_stream():
+        ...
+
+    hex_id = entry.id.hex
+    assert client.exists(f"{key_prefix}:entry:{hex_id}") == 1
+    assert client.exists(f"{key_prefix}:stream:{hex_id}") == 1
+    assert client.exists(f"{key_prefix}:stream_done:{hex_id}") == 1

--- a/tests/_core/_sync/test_redis_storage.py
+++ b/tests/_core/_sync/test_redis_storage.py
@@ -390,9 +390,9 @@ def test_hishel_ttl_sets_redis_key_expiry() -> None:
     entry.response.read()
 
     hex_id = entry.id.hex
-    entry_ttl = client.ttl(f"hishel:entry:{hex_id}")
-    assert isinstance(entry_ttl, int)
-    assert 0 < entry_ttl <= 42
+    entry_pttl = client.pttl(f"hishel:entry:{hex_id}")
+    assert isinstance(entry_pttl, int)
+    assert 0 < entry_pttl <= 42000
 
 
 

--- a/tests/_core/_sync/test_redis_storage.py
+++ b/tests/_core/_sync/test_redis_storage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 import uuid
 from dataclasses import replace
 from datetime import datetime
@@ -185,6 +186,31 @@ def test_update_entry_with_new_entry() -> None:
 
     assert result is not None
     assert result.cache_key == b"key2"
+
+
+
+def test_refresh_ttl_on_access() -> None:
+    """Test that update_entry resets the Redis key TTL when created_at is refreshed."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    with travel(datetime(2024, 1, 1, 0, 0, 0, tzinfo=ZoneInfo("UTC"))):
+        entry = storage.create_entry(
+            request=Request(method="GET", url="https://example.com", metadata={"hishel_ttl": 60}),
+            response=Response(status_code=200, stream=make_sync_iterator([b"data"])),
+            key="test_key",
+            id_=uuid.UUID(int=15),
+        )
+        entry.response.read()
+
+    # Advance 30 s — half the TTL consumed, ~30 000 ms remaining
+    with travel(datetime(2024, 1, 1, 0, 0, 30, tzinfo=ZoneInfo("UTC"))):
+        storage.update_entry(
+            entry.id,
+            lambda e: replace(e, meta=replace(e.meta, created_at=time.time())),
+        )
+        pttl = cast(int, client.pttl(f"hishel:entry:{entry.id.hex}"))
+        assert pttl > 30_000  # reset to the full 60 s, not just the remaining ~30 s
 
 
 

--- a/tests/_core/_sync/test_redis_storage.py
+++ b/tests/_core/_sync/test_redis_storage.py
@@ -353,6 +353,25 @@ def test_custom_ttl() -> None:
 
 
 
+def test_hishel_ttl_sets_redis_key_expiry() -> None:
+    """Test that hishel_ttl in request metadata sets the Redis key TTL, not just the Python-level check."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com", metadata={"hishel_ttl": 42}),
+        response=Response(status_code=200, stream=make_sync_iterator([b"data"])),
+        key="test_key",
+        id_=uuid.UUID(int=14),
+    )
+    entry.response.read()
+
+    hex_id = entry.id.hex
+    entry_ttl = client.ttl(f"hishel:entry:{hex_id}")
+    assert 0 < entry_ttl <= 42
+
+
+
 def test_custom_prefix() -> None:
     """Test checking custom redis key prefix."""
     client = fakeredis.FakeRedis()

--- a/tests/_core/_sync/test_redis_storage.py
+++ b/tests/_core/_sync/test_redis_storage.py
@@ -368,6 +368,7 @@ def test_hishel_ttl_sets_redis_key_expiry() -> None:
 
     hex_id = entry.id.hex
     entry_ttl = client.ttl(f"hishel:entry:{hex_id}")
+    assert isinstance(entry_ttl, int)
     assert 0 < entry_ttl <= 42
 
 

--- a/tests/_core/_sync/test_redis_storage.py
+++ b/tests/_core/_sync/test_redis_storage.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from dataclasses import replace
 from datetime import datetime
-from typing import Iterator
+from typing import Iterator, Awaitable, cast
 from unittest.mock import MagicMock
 from zoneinfo import ZoneInfo
 
@@ -189,7 +189,7 @@ def test_update_entry_with_new_entry() -> None:
 
 
 def test_remove_entry() -> None:
-    """Test that remove_entry hard-deletes all Redis keys for the entry."""
+    """Test that remove_entry soft-deletes the entry and hides it from get_entries."""
     client = fakeredis.FakeRedis()
     storage = RedisStorage(client=client)
 
@@ -204,9 +204,32 @@ def test_remove_entry() -> None:
     storage.remove_entry(entry.id)
 
     hex_id = entry.id.hex
-    assert client.exists(f"hishel:entry:{hex_id}") == 0
-    assert client.exists(f"hishel:stream:{hex_id}") == 0
-    assert client.exists(f"hishel:stream_done:{hex_id}") == 0
+    # Keys still exist (soft delete, not hard delete)
+    assert client.exists(f"hishel:entry:{hex_id}") == 1
+    # A TTL has been set on the entry key
+    assert 0 < cast(int, client.ttl(f"hishel:entry:{hex_id}")) <= 180
+    # Soft-deleted entry is invisible to get_entries
+    assert storage.get_entries("test_key") == []
+
+
+
+def test_remove_entry_custom_soft_delete_ttl() -> None:
+    """Test that a custom soft_delete_ttl is applied to Redis keys after remove_entry."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client, soft_delete_ttl=60)
+
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"data"])),
+        key="test_key",
+        id_=uuid.UUID(int=70),
+    )
+    entry.response.read()
+
+    storage.remove_entry(entry.id)
+
+    hex_id = entry.id.hex
+    assert 0 < cast(int, client.ttl(f"hishel:entry:{hex_id}")) <= 60
 
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -61,6 +61,15 @@ wheels = [
 ]
 
 [[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -547,6 +556,20 @@ wheels = [
 ]
 
 [[package]]
+name = "fakeredis"
+version = "2.35.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "redis" },
+    { name = "sortedcontainers" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/50/b748233c02fa77e5105238190cc9bb58b852eb1c8b1d0763230d3a5b745a/fakeredis-2.35.1.tar.gz", hash = "sha256:5bae5eba7b9d93cb968944ac40936373cf2397ff71667d4b595df65c3d2e413f", size = 189118, upload-time = "2026-04-12T17:05:58.539Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/27/b8b057a23f7777177e92d3a602fd866751b6b45014964548997e92e048fd/fakeredis-2.35.1-py3-none-any.whl", hash = "sha256:67d97e11f562b7870e11e5c30cf182270bfb2dd37f6707dba47cc6d91628d1b9", size = 129678, upload-time = "2026-04-12T17:05:56.86Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.136.0"
 source = { registry = "https://pypi.org/simple" }
@@ -850,6 +873,9 @@ httpx = [
     { name = "anysqlite" },
     { name = "httpx" },
 ]
+redis = [
+    { name = "redis" },
+]
 requests = [
     { name = "requests" },
 ]
@@ -859,6 +885,7 @@ dev = [
     { name = "anyio" },
     { name = "anysqlite" },
     { name = "coverage" },
+    { name = "fakeredis" },
     { name = "fastapi", extra = ["standard"] },
     { name = "hatch" },
     { name = "inline-snapshot" },
@@ -872,6 +899,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-icdiff" },
+    { name = "redis" },
     { name = "ruff" },
     { name = "time-machine" },
     { name = "trio" },
@@ -890,16 +918,18 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'fastapi'", specifier = ">=0.119.1" },
     { name = "httpx", marker = "extra == 'httpx'", specifier = ">=0.28.1" },
     { name = "msgpack", specifier = ">=1.1.2" },
+    { name = "redis", marker = "extra == 'redis'", specifier = ">=6.2.0" },
     { name = "requests", marker = "extra == 'requests'", specifier = ">=2.32.5" },
     { name = "typing-extensions", specifier = ">=4.14.1" },
 ]
-provides-extras = ["async", "requests", "httpx", "fastapi"]
+provides-extras = ["async", "requests", "httpx", "fastapi", "redis"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "anyio", specifier = "==4.12.1" },
     { name = "anysqlite", specifier = ">=0.0.5" },
     { name = "coverage", specifier = "==7.10.7" },
+    { name = "fakeredis", specifier = ">=2.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.119.1" },
     { name = "hatch", specifier = "==1.15.1" },
     { name = "inline-snapshot", specifier = ">=0.28.0" },
@@ -913,6 +943,7 @@ dev = [
     { name = "pytest", specifier = "==8.4.2" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-icdiff", specifier = ">=0.9" },
+    { name = "redis", specifier = ">=6.2.0" },
     { name = "ruff", specifier = "==0.14.14" },
     { name = "time-machine", specifier = ">=2.19.0" },
     { name = "trio", specifier = "==0.31.0" },
@@ -2136,6 +2167,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
+]
+
+[[package]]
+name = "redis"
+version = "7.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/7f/3759b1d0d72b7c92f0d70ffd9dc962b7b7b5ee74e135f9d7d8ab06b8a318/redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad", size = 4943913, upload-time = "2026-03-24T09:14:37.53Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/3a/95deec7db1eb53979973ebd156f3369a72732208d1391cd2e5d127062a32/redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec", size = 409772, upload-time = "2026-03-24T09:14:35.968Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR aims at adding Redis storage for hishel. It probably lacks documentation and some things might be wrong but I thought it could help.

Add AsyncRedisStorage backend backed by redis-py (redis>=6.2.0, as that's the version hishel 0.1.5 supported). 

The sync RedisStorage is auto-generated via scripts/unasync. Unit tests written for the async variant and auto-generated for sync, using fakeredis for in-memory Redis simulation.

Also updates scripts/unasync with Redis-specific substitution rules and file pairs, and adds redis as an optional project dependency.

resolves #425 