### PR TITLE
feat: add support for redis

### DIFF
--- a/docs/storages.md
+++ b/docs/storages.md
@@ -89,3 +89,133 @@ storage = AsyncSqliteStorage(refresh_ttl_on_access=True)
 :::
 
 You can also control this on a per-request basis by setting the `hishel_refresh_ttl_on_access` request metadata to `True` or `False`, which overrides the storage default.
+
+## Redis Storage
+
+Redis storage provides fast, in-memory (or persistent) caching backed by a Redis server.
+
+::: code-group
+
+```python [Sync]
+from redis import Redis
+from hishel import RedisStorage
+
+client = Redis(host="localhost", port=6379)
+storage = RedisStorage(client=client)
+```
+
+```python [Async]
+from redis.asyncio import Redis
+from hishel import AsyncRedisStorage
+
+client = Redis(host="localhost", port=6379)
+storage = AsyncRedisStorage(client=client)
+```
+
+:::
+
+### Custom Key Prefix
+
+You can set a custom prefix for all Redis keys. This is useful when sharing a Redis instance across multiple applications:
+
+::: code-group
+
+```python [Sync]
+from redis import Redis
+from hishel import RedisStorage
+
+client = Redis(host="localhost", port=6379)
+storage = RedisStorage(client=client, key_prefix="myapp")
+```
+
+```python [Async]
+from redis.asyncio import Redis
+from hishel import AsyncRedisStorage
+
+client = Redis(host="localhost", port=6379)
+storage = AsyncRedisStorage(client=client, key_prefix="myapp")
+```
+
+:::
+
+### Default Entry TTL
+
+You can set a default TTL for all entries stored in Redis. This value is used when the request does not specify its own TTL:
+
+::: code-group
+
+```python [Sync]
+from redis import Redis
+from hishel import RedisStorage
+
+client = Redis(host="localhost", port=6379)
+storage = RedisStorage(client=client, ttl=3600)
+```
+
+```python [Async]
+from redis.asyncio import Redis
+from hishel import AsyncRedisStorage
+
+client = Redis(host="localhost", port=6379)
+storage = AsyncRedisStorage(client=client, ttl=3600)
+```
+
+:::
+
+Storage also respects the `hishel_ttl` request metadata, which can be used to set a custom TTL for a specific request, overriding the storage default.
+
+### Soft-Delete Buffer TTL
+
+When an entry is removed, hishel soft-deletes it (marks `deleted_at`) and sets a short TTL on the underlying Redis keys so that any concurrent request still reading that entry's stream can finish before the data disappears. After the buffer expires, Redis cleans up the keys automatically.
+
+The default buffer is 180 seconds (3 minutes). You can tune it:
+
+::: code-group
+
+```python [Sync]
+from redis import Redis
+from hishel import RedisStorage
+
+client = Redis(host="localhost", port=6379)
+storage = RedisStorage(client=client, soft_delete_ttl=60)
+```
+
+```python [Async]
+from redis.asyncio import Redis
+from hishel import AsyncRedisStorage
+
+client = Redis(host="localhost", port=6379)
+storage = AsyncRedisStorage(client=client, soft_delete_ttl=60)
+```
+
+:::
+
+Soft-deleted entries are invisible to `get_entries`, so new requests will never receive them even while the keys are still present in Redis.
+
+### Max Stream Size
+
+Hishel streams response bodies into Redis chunk by chunk as the client reads them. Without a cap, a misbehaving or malicious upstream that keeps streaming bytes could push gigabytes into your Redis server before anyone notices.
+
+`max_stream_size` (in bytes) bounds how much of a single response body hishel will write to Redis. Once the limit is exceeded, hishel drops the partial chunks it had already written, stops caching that response, and silently passes the remaining bytes through to the client — the request still succeeds, it just won't be cached.
+
+The default is 10 MiB, which comfortably covers typical JSON, HTML, and small media responses. Tune it for your workload, or set it to `None` to disable the cap entirely:
+
+::: code-group
+
+```python [Sync]
+from redis import Redis
+from hishel import RedisStorage
+
+client = Redis(host="localhost", port=6379)
+storage = RedisStorage(client=client, max_stream_size=50 * 1024 * 1024)
+```
+
+```python [Async]
+from redis.asyncio import Redis
+from hishel import AsyncRedisStorage
+
+client = Redis(host="localhost", port=6379)
+storage = AsyncRedisStorage(client=client, max_stream_size=50 * 1024 * 1024)
+```
+
+:::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ httpx = [
 fastapi = [
     "fastapi>=0.119.1",
 ]
+redis = [
+    "redis>=7.0.0",
+]
 
 [project.urls]
 Homepage = "https://hishel.com"
@@ -59,8 +62,8 @@ exclude = ['venv', '.venv']
 [[tool.mypy.overrides]]
 module = "tests.*"
 disallow_untyped_defs = false
-
 check_untyped_defs = true
+
 [[tool.mypy.overrides]]
 module = ["time_machine.*", "msgpack.*"]
 ignore_missing_imports = true
@@ -83,8 +86,8 @@ exclude = [
     "src/hishel/_sync_cache.py",
     "tests/test_sync_httpx.py",
     "src/hishel/_core/_storages/_sync_sqlite.py",
+    "src/hishel/_core/_storages/_sync_redis.py",
     "src/hishel/_core/_storages/_sync_base.py",
-    "tests/test_sync_httpx.py",
     "src/hishel/_sync_httpx.py"
 ]
 line-length = 120
@@ -120,5 +123,8 @@ dev = [
     "types-boto3==1.42.39",
     "types-pyyaml==6.0.12.20250915",
     "types-requests>=2.31.0.6",
+    "fakeredis>=2.0",
+    "redis>=7.0.0",
     "zipp>=3.19.1",
+    "types-redis>=4.6.0.20241004",
 ]

--- a/scripts/unasync
+++ b/scripts/unasync
@@ -27,7 +27,14 @@ SUBS = [
     ("AsyncBaseStorage", "SyncBaseStorage"),
     ("AsyncCacheClient", "SyncCacheClient"),
     ("AsyncSqliteStorage", "SyncSqliteStorage"),
+    ("AsyncRedisStorage", "RedisStorage"),
     ("anysqlite", "sqlite3"),
+    ("redis.asyncio", "redis"),
+    ("fakeredis.aioredis", "fakeredis"),
+    (
+        "hishel._core._storages._async_redis",
+        "hishel._core._storages._sync_redis",
+    ),
     ("@pytest.mark.anyio", ""),
     ("from anyio import Lock", "from threading import RLock"),
     ("self._lock = Lock", "self._lock = RLock"),
@@ -110,6 +117,8 @@ def main():
         ("tests/test_async_httpx.py", "tests/test_sync_httpx.py"),
         ("src/hishel/_async_cache.py", "src/hishel/_sync_cache.py"),
         ("src/hishel/_core/_storages/_async_base.py", "src/hishel/_core/_storages/_sync_base.py"),
+        ("src/hishel/_core/_storages/_async_redis.py", "src/hishel/_core/_storages/_sync_redis.py"),
+        ("tests/_core/_async/test_redis_storage.py", "tests/_core/_sync/test_redis_storage.py"),
         ("src/hishel/_async_httpx.py", "src/hishel/_sync_httpx.py"),
     ]
 

--- a/src/hishel/__init__.py
+++ b/src/hishel/__init__.py
@@ -1,7 +1,9 @@
 from hishel._core._storages._async_sqlite import AsyncSqliteStorage
 from hishel._core._storages._async_base import AsyncBaseStorage
+from hishel._core._storages._async_redis import AsyncRedisStorage
 from hishel._core._storages._sync_sqlite import SyncSqliteStorage
 from hishel._core._storages._sync_base import SyncBaseStorage
+from hishel._core._storages._sync_redis import RedisStorage
 from hishel._core._headers import Headers as Headers
 from hishel._core._spec import (
     AnyState as AnyState,
@@ -58,6 +60,8 @@ __all__ = (
     "AsyncBaseStorage",
     "SyncSqliteStorage",
     "AsyncSqliteStorage",
+    "RedisStorage",
+    "AsyncRedisStorage",
     # Proxy
     "AsyncCacheProxy",
     "SyncCacheProxy",

--- a/src/hishel/_core/_storages/_async_redis.py
+++ b/src/hishel/_core/_storages/_async_redis.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncIterator, Callable
+from dataclasses import replace
+from time import time
+from typing import TYPE_CHECKING, cast
+from uuid import UUID, uuid4
+
+from hishel._core._storages._async_base import AsyncBaseStorage
+from hishel._core._storages._packing import pack, unpack
+from hishel._core.models import Entry, EntryMeta, Request, Response
+
+if TYPE_CHECKING:
+    from redis import RedisError
+    from redis.asyncio import Redis
+else:
+    try:
+        from redis import RedisError
+        from redis.asyncio import Redis
+    except ImportError:
+        RedisError = None
+        Redis = None
+
+
+class AsyncRedisStorage(AsyncBaseStorage):
+    def __init__(
+        self,
+        client: Redis[bytes],
+        ttl: int | float = 3600,
+        key_prefix: str = "hishel",
+        soft_delete_ttl: int = 180,
+        max_stream_size: int | None = 10 * 1024 * 1024,
+    ) -> None:
+        if Redis is None:
+            raise ImportError(
+                "The 'redis' library is required to use the `AsyncRedisStorage` integration. "
+                "Install hishel with 'pip install hishel[redis]'."
+            )
+
+        self._client = client
+        self._default_ttl = ttl
+        self._key_prefix = key_prefix
+        self._soft_delete_ttl = soft_delete_ttl
+        self._max_stream_size = max_stream_size
+
+    def _effective_ttl(self, request: Request) -> int | float:
+        """Determine the effective TTL for a request, prioritizing request-specific metadata over the default TTL."""
+        return cast(int | float, request.metadata.get("hishel_ttl", self._default_ttl))
+
+    def _safe_ttl_ms(self, request: Request) -> int:
+        """
+        Returns the Redis-level TTL in milliseconds: effective TTL + soft_delete_ttl.
+
+        This ensures Redis doesn't physically delete the entry the moment it logically
+        expires; instead, the entry survives long enough to be soft-deleted by
+        get_entries, and Redis only reclaims it as a safety net afterward.
+        """
+        return int((self._effective_ttl(request) + self._soft_delete_ttl) * 1000)
+
+    async def create_entry(self, request: Request, response: Response, key: str, id_: UUID | None = None) -> Entry:
+        pair_id = id_ or uuid4()
+        key_bytes = key.encode()
+        safe_ttl_ms = self._safe_ttl_ms(request)
+
+        assert isinstance(response.stream, AsyncIterator), "Response stream must be an AsyncIterator"
+        response_with_stream = replace(
+            response,
+            stream=self._save_stream(response.stream, pair_id, safe_ttl_ms),
+        )
+
+        entry = Entry(
+            id=pair_id,
+            request=request,
+            response=response_with_stream,
+            meta=EntryMeta(created_at=time()),
+            cache_key=key_bytes,
+        )
+
+        packed = pack(entry, kind="pair")
+        entry_key = f"{self._key_prefix}:entry:{pair_id.hex}"
+        idx_key = f"{self._key_prefix}:idx:{key}"
+
+        async with self._client.pipeline(transaction=True) as pipe:
+            pipe.set(entry_key, packed, px=safe_ttl_ms)
+            pipe.sadd(idx_key, pair_id.hex)
+            pipe.pexpire(idx_key, safe_ttl_ms)
+            await pipe.execute()
+
+        return entry
+
+    async def _save_stream(self, stream: AsyncIterator[bytes], pair_id: UUID, safe_ttl_ms: int) -> AsyncIterator[bytes]:
+        stream_key = f"{self._key_prefix}:stream:{pair_id.hex}"
+        done_key = f"{self._key_prefix}:stream_done:{pair_id.hex}"
+        completed = False
+        aborted = False
+        ttl_set = False
+        total_size = 0
+
+        try:
+            async for chunk in stream:
+                if not aborted:
+                    total_size += len(chunk)
+                    if self._max_stream_size is not None and total_size > self._max_stream_size:
+                        aborted = True
+                        with contextlib.suppress(RedisError):
+                            await self._client.delete(stream_key, done_key)
+                    else:
+                        await self._client.rpush(stream_key, chunk)
+                        if not ttl_set:
+                            # Set a TTL immediately after the first write so the key
+                            # can't outlive the process if we die mid-stream (SIGKILL,
+                            # OOM, host failure) before reaching the cleanup block.
+                            await self._client.pexpire(stream_key, safe_ttl_ms)
+                            ttl_set = True
+                yield chunk
+
+            if not aborted:
+                # sentinel to mark end of stream
+                await self._client.rpush(stream_key, b"")
+                await self._client.set(done_key, b"1")
+                await self._client.pexpire(stream_key, safe_ttl_ms)
+                await self._client.pexpire(done_key, safe_ttl_ms)
+            completed = True
+        finally:
+            if not completed:
+                # Upstream errored, or the consumer aborted (e.g. GeneratorExit
+                # from an `aclose()`). Drop whatever partial data we wrote so
+                # we don't leave an orphan stream key without a TTL. Suppress
+                # Redis errors here — we're already on an error path and don't
+                # want to mask the original exception.
+                with contextlib.suppress(RedisError):
+                    await self._client.delete(stream_key, done_key)
+
+    async def _is_stream_complete(self, entry_id: UUID) -> bool:
+        result = await self._client.exists(f"{self._key_prefix}:stream_done:{entry_id.hex}")
+        return bool(result)
+
+    def _is_pair_expired(self, pair: Entry) -> bool:
+        return pair.meta.created_at + self._effective_ttl(pair.request) < time()
+
+    async def _stream_from_cache(self, entry_id: UUID) -> AsyncIterator[bytes]:
+        stream_key = f"{self._key_prefix}:stream:{entry_id.hex}"
+        length = await self._client.llen(stream_key)
+        for i in range(length - 1):  # -1 excludes the sentinel
+            chunk = await self._client.lindex(stream_key, i)
+            if chunk is not None:
+                yield chunk.encode() if isinstance(chunk, str) else chunk
+
+    async def get_entries(self, key: str) -> list[Entry]:
+        idx_key = f"{self._key_prefix}:idx:{key}"
+        members = await self._client.smembers(idx_key)
+
+        result: list[Entry] = []
+        for member in members:
+            hex_str = member.decode() if isinstance(member, bytes) else member
+            entry_key = f"{self._key_prefix}:entry:{hex_str}"
+
+            data = await self._client.get(entry_key)
+            if data is None:
+                await self._client.srem(idx_key, member)
+                continue
+
+            entry = unpack(data, kind="pair")
+            if entry is None:
+                continue
+
+            if not await self._is_stream_complete(entry.id):
+                continue
+
+            if self._is_pair_expired(entry):
+                # Logically expired but still present in Redis: soft-delete it now.
+                if not self.is_soft_deleted(entry):
+                    await self.remove_entry(entry.id)
+                continue
+
+            if self.is_soft_deleted(entry):
+                continue
+
+            result.append(
+                replace(
+                    entry,
+                    response=replace(entry.response, stream=self._stream_from_cache(entry.id)),
+                )
+            )
+
+        return result
+
+    async def update_entry(
+        self,
+        id: UUID,  # noqa: A002
+        new_entry: Entry | Callable[[Entry], Entry],
+    ) -> Entry | None:
+        entry_key = f"{self._key_prefix}:entry:{id.hex}"
+        data = await self._client.get(entry_key)
+        if data is None:
+            return None
+
+        existing = unpack(data, kind="pair")
+
+        updated = new_entry(existing) if callable(new_entry) else new_entry
+
+        if existing.id != updated.id:
+            raise ValueError("Entry ID mismatch")
+
+        packed = pack(updated, kind="pair")
+
+        # Preserve the remaining TTL atomically. `xx=True` ensures we don't
+        # resurrect an entry that expired between the GET above and this SET;
+        # `keepttl=True` preserves the existing expiry without an extra PTTL
+        # round trip (and without the TOCTOU it would introduce).
+        result = await self._client.set(entry_key, packed, xx=True, keepttl=True)
+        if result is None:
+            # Entry expired between GET and SET; nothing to update.
+            return None
+
+        if existing.cache_key != updated.cache_key:
+            old_key = existing.cache_key.decode() if isinstance(existing.cache_key, bytes) else existing.cache_key
+            new_key = updated.cache_key.decode() if isinstance(updated.cache_key, bytes) else updated.cache_key
+            await self._client.srem(f"{self._key_prefix}:idx:{old_key}", id.hex)
+            await self._client.sadd(f"{self._key_prefix}:idx:{new_key}", id.hex)
+
+        return updated
+
+    async def refresh_entry_ttl(self, id: UUID) -> None:  # noqa: A002
+        """Reset all keys associated with the entry to the full safe TTL."""
+        entry_key = f"{self._key_prefix}:entry:{id.hex}"
+        data = await self._client.get(entry_key)
+        if data is None:
+            return
+
+        entry = unpack(data, kind="pair")
+        if entry is None:
+            return
+
+        safe_ttl_ms = self._safe_ttl_ms(entry.request)
+        stream_key = f"{self._key_prefix}:stream:{id.hex}"
+        done_key = f"{self._key_prefix}:stream_done:{id.hex}"
+        idx_key = f"{self._key_prefix}:idx:{entry.cache_key.decode()}"
+
+        await self._client.pexpire(entry_key, safe_ttl_ms)
+        await self._client.pexpire(stream_key, safe_ttl_ms)
+        await self._client.pexpire(done_key, safe_ttl_ms)
+        await self._client.pexpire(idx_key, safe_ttl_ms)
+
+    async def remove_entry(self, id: UUID) -> None:  # noqa: A002
+        entry_key = f"{self._key_prefix}:entry:{id.hex}"
+        stream_key = f"{self._key_prefix}:stream:{id.hex}"
+        done_key = f"{self._key_prefix}:stream_done:{id.hex}"
+        with contextlib.suppress(RedisError):
+            data = await self._client.get(entry_key)
+            if data is None:
+                return
+            entry = unpack(data, kind="pair")
+            if entry is None:
+                return
+
+            # Remove from the index first so concurrent get_entries() calls
+            # stop finding this entry immediately. The blob itself is left
+            # behind with a short TTL so any in-flight stream reader can
+            # finish; Redis reclaims the keys when soft_delete_ttl elapses.
+            idx_key = f"{self._key_prefix}:idx:{entry.cache_key.decode()}"
+            await self._client.srem(idx_key, id.hex)
+            await self._client.expire(entry_key, self._soft_delete_ttl)
+            await self._client.expire(stream_key, self._soft_delete_ttl)
+            await self._client.expire(done_key, self._soft_delete_ttl)
+
+    async def close(self) -> None:
+        await self._client.aclose()  # type: ignore[attr-defined]

--- a/src/hishel/_core/_storages/_sync_redis.py
+++ b/src/hishel/_core/_storages/_sync_redis.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Iterator, Callable
+from dataclasses import replace
+from time import time
+from typing import TYPE_CHECKING, cast
+from uuid import UUID, uuid4
+
+from hishel._core._storages._sync_base import SyncBaseStorage
+from hishel._core._storages._packing import pack, unpack
+from hishel._core.models import Entry, EntryMeta, Request, Response
+
+if TYPE_CHECKING:
+    from redis import RedisError
+    from redis import Redis
+else:
+    try:
+        from redis import RedisError
+        from redis import Redis
+    except ImportError:
+        RedisError = None
+        Redis = None
+
+
+class RedisStorage(SyncBaseStorage):
+    def __init__(
+        self,
+        client: Redis[bytes],
+        ttl: int | float = 3600,
+        key_prefix: str = "hishel",
+        soft_delete_ttl: int = 180,
+        max_stream_size: int | None = 10 * 1024 * 1024,
+    ) -> None:
+        if Redis is None:
+            raise ImportError(
+                "The 'redis' library is required to use the `RedisStorage` integration. "
+                "Install hishel with 'pip install hishel[redis]'."
+            )
+
+        self._client = client
+        self._default_ttl = ttl
+        self._key_prefix = key_prefix
+        self._soft_delete_ttl = soft_delete_ttl
+        self._max_stream_size = max_stream_size
+
+    def _effective_ttl(self, request: Request) -> int | float:
+        """Determine the effective TTL for a request, prioritizing request-specific metadata over the default TTL."""
+        return cast(int | float, request.metadata.get("hishel_ttl", self._default_ttl))
+
+    def _safe_ttl_ms(self, request: Request) -> int:
+        """
+        Returns the Redis-level TTL in milliseconds: effective TTL + soft_delete_ttl.
+
+        This ensures Redis doesn't physically delete the entry the moment it logically
+        expires; instead, the entry survives long enough to be soft-deleted by
+        get_entries, and Redis only reclaims it as a safety net afterward.
+        """
+        return int((self._effective_ttl(request) + self._soft_delete_ttl) * 1000)
+
+    def create_entry(self, request: Request, response: Response, key: str, id_: UUID | None = None) -> Entry:
+        pair_id = id_ or uuid4()
+        key_bytes = key.encode()
+        safe_ttl_ms = self._safe_ttl_ms(request)
+
+        assert isinstance(response.stream, Iterator), "Response stream must be an Iterator"
+        response_with_stream = replace(
+            response,
+            stream=self._save_stream(response.stream, pair_id, safe_ttl_ms),
+        )
+
+        entry = Entry(
+            id=pair_id,
+            request=request,
+            response=response_with_stream,
+            meta=EntryMeta(created_at=time()),
+            cache_key=key_bytes,
+        )
+
+        packed = pack(entry, kind="pair")
+        entry_key = f"{self._key_prefix}:entry:{pair_id.hex}"
+        idx_key = f"{self._key_prefix}:idx:{key}"
+
+        with self._client.pipeline(transaction=True) as pipe:
+            pipe.set(entry_key, packed, px=safe_ttl_ms)
+            pipe.sadd(idx_key, pair_id.hex)
+            pipe.pexpire(idx_key, safe_ttl_ms)
+            pipe.execute()
+
+        return entry
+
+    def _save_stream(self, stream: Iterator[bytes], pair_id: UUID, safe_ttl_ms: int) -> Iterator[bytes]:
+        stream_key = f"{self._key_prefix}:stream:{pair_id.hex}"
+        done_key = f"{self._key_prefix}:stream_done:{pair_id.hex}"
+        completed = False
+        aborted = False
+        ttl_set = False
+        total_size = 0
+
+        try:
+            for chunk in stream:
+                if not aborted:
+                    total_size += len(chunk)
+                    if self._max_stream_size is not None and total_size > self._max_stream_size:
+                        aborted = True
+                        with contextlib.suppress(RedisError):
+                            self._client.delete(stream_key, done_key)
+                    else:
+                        self._client.rpush(stream_key, chunk)
+                        if not ttl_set:
+                            # Set a TTL immediately after the first write so the key
+                            # can't outlive the process if we die mid-stream (SIGKILL,
+                            # OOM, host failure) before reaching the cleanup block.
+                            self._client.pexpire(stream_key, safe_ttl_ms)
+                            ttl_set = True
+                yield chunk
+
+            if not aborted:
+                # sentinel to mark end of stream
+                self._client.rpush(stream_key, b"")
+                self._client.set(done_key, b"1")
+                self._client.pexpire(stream_key, safe_ttl_ms)
+                self._client.pexpire(done_key, safe_ttl_ms)
+            completed = True
+        finally:
+            if not completed:
+                # Upstream errored, or the consumer aborted (e.g. GeneratorExit
+                # from an `close()`). Drop whatever partial data we wrote so
+                # we don't leave an orphan stream key without a TTL. Suppress
+                # Redis errors here — we're already on an error path and don't
+                # want to mask the original exception.
+                with contextlib.suppress(RedisError):
+                    self._client.delete(stream_key, done_key)
+
+    def _is_stream_complete(self, entry_id: UUID) -> bool:
+        result = self._client.exists(f"{self._key_prefix}:stream_done:{entry_id.hex}")
+        return bool(result)
+
+    def _is_pair_expired(self, pair: Entry) -> bool:
+        return pair.meta.created_at + self._effective_ttl(pair.request) < time()
+
+    def _stream_from_cache(self, entry_id: UUID) -> Iterator[bytes]:
+        stream_key = f"{self._key_prefix}:stream:{entry_id.hex}"
+        length = self._client.llen(stream_key)
+        for i in range(length - 1):  # -1 excludes the sentinel
+            chunk = self._client.lindex(stream_key, i)
+            if chunk is not None:
+                yield chunk.encode() if isinstance(chunk, str) else chunk
+
+    def get_entries(self, key: str) -> list[Entry]:
+        idx_key = f"{self._key_prefix}:idx:{key}"
+        members = self._client.smembers(idx_key)
+
+        result: list[Entry] = []
+        for member in members:
+            hex_str = member.decode() if isinstance(member, bytes) else member
+            entry_key = f"{self._key_prefix}:entry:{hex_str}"
+
+            data = self._client.get(entry_key)
+            if data is None:
+                self._client.srem(idx_key, member)
+                continue
+
+            entry = unpack(data, kind="pair")
+            if entry is None:
+                continue
+
+            if not self._is_stream_complete(entry.id):
+                continue
+
+            if self._is_pair_expired(entry):
+                # Logically expired but still present in Redis: soft-delete it now.
+                if not self.is_soft_deleted(entry):
+                    self.remove_entry(entry.id)
+                continue
+
+            if self.is_soft_deleted(entry):
+                continue
+
+            result.append(
+                replace(
+                    entry,
+                    response=replace(entry.response, stream=self._stream_from_cache(entry.id)),
+                )
+            )
+
+        return result
+
+    def update_entry(
+        self,
+        id: UUID,  # noqa: A002
+        new_entry: Entry | Callable[[Entry], Entry],
+    ) -> Entry | None:
+        entry_key = f"{self._key_prefix}:entry:{id.hex}"
+        data = self._client.get(entry_key)
+        if data is None:
+            return None
+
+        existing = unpack(data, kind="pair")
+
+        updated = new_entry(existing) if callable(new_entry) else new_entry
+
+        if existing.id != updated.id:
+            raise ValueError("Entry ID mismatch")
+
+        packed = pack(updated, kind="pair")
+
+        # Preserve the remaining TTL atomically. `xx=True` ensures we don't
+        # resurrect an entry that expired between the GET above and this SET;
+        # `keepttl=True` preserves the existing expiry without an extra PTTL
+        # round trip (and without the TOCTOU it would introduce).
+        result = self._client.set(entry_key, packed, xx=True, keepttl=True)
+        if result is None:
+            # Entry expired between GET and SET; nothing to update.
+            return None
+
+        if existing.cache_key != updated.cache_key:
+            old_key = existing.cache_key.decode() if isinstance(existing.cache_key, bytes) else existing.cache_key
+            new_key = updated.cache_key.decode() if isinstance(updated.cache_key, bytes) else updated.cache_key
+            self._client.srem(f"{self._key_prefix}:idx:{old_key}", id.hex)
+            self._client.sadd(f"{self._key_prefix}:idx:{new_key}", id.hex)
+
+        return updated
+
+    def refresh_entry_ttl(self, id: UUID) -> None:  # noqa: A002
+        """Reset all keys associated with the entry to the full safe TTL."""
+        entry_key = f"{self._key_prefix}:entry:{id.hex}"
+        data = self._client.get(entry_key)
+        if data is None:
+            return
+
+        entry = unpack(data, kind="pair")
+        if entry is None:
+            return
+
+        safe_ttl_ms = self._safe_ttl_ms(entry.request)
+        stream_key = f"{self._key_prefix}:stream:{id.hex}"
+        done_key = f"{self._key_prefix}:stream_done:{id.hex}"
+        idx_key = f"{self._key_prefix}:idx:{entry.cache_key.decode()}"
+
+        self._client.pexpire(entry_key, safe_ttl_ms)
+        self._client.pexpire(stream_key, safe_ttl_ms)
+        self._client.pexpire(done_key, safe_ttl_ms)
+        self._client.pexpire(idx_key, safe_ttl_ms)
+
+    def remove_entry(self, id: UUID) -> None:  # noqa: A002
+        entry_key = f"{self._key_prefix}:entry:{id.hex}"
+        stream_key = f"{self._key_prefix}:stream:{id.hex}"
+        done_key = f"{self._key_prefix}:stream_done:{id.hex}"
+        with contextlib.suppress(RedisError):
+            data = self._client.get(entry_key)
+            if data is None:
+                return
+            entry = unpack(data, kind="pair")
+            if entry is None:
+                return
+
+            # Remove from the index first so concurrent get_entries() calls
+            # stop finding this entry immediately. The blob itself is left
+            # behind with a short TTL so any in-flight stream reader can
+            # finish; Redis reclaims the keys when soft_delete_ttl elapses.
+            idx_key = f"{self._key_prefix}:idx:{entry.cache_key.decode()}"
+            self._client.srem(idx_key, id.hex)
+            self._client.expire(entry_key, self._soft_delete_ttl)
+            self._client.expire(stream_key, self._soft_delete_ttl)
+            self._client.expire(done_key, self._soft_delete_ttl)
+
+    def close(self) -> None:
+        self._client.close()  # type: ignore[attr-defined]

--- a/tests/_core/_async/test_redis_storage.py
+++ b/tests/_core/_async/test_redis_storage.py
@@ -1,0 +1,483 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import replace
+from datetime import datetime
+from typing import Iterator
+from unittest.mock import MagicMock
+from zoneinfo import ZoneInfo
+
+import fakeredis
+import pytest
+from time_machine import travel
+
+from hishel import Request, Response
+from hishel._core._storages._sync_redis import RedisStorage
+from hishel._utils import make_sync_iterator
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    # redis is asyncio-only; restrict async tests to asyncio backend
+    return "asyncio"
+
+
+def test_add_entry() -> None:
+    """Test adding a complete entry with request and response."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"response data"])),
+        key="test_key",
+        id_=uuid.UUID(int=0),
+    )
+
+    for _ in entry.response._iter_stream():
+        ...
+
+    entries = storage.get_entries("test_key")
+    assert len(entries) == 1
+    assert entries[0].cache_key == b"test_key"
+
+
+def test_add_entry_with_stream() -> None:
+    """Test adding an entry with a multi-chunk streaming response body."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    entry = storage.create_entry(
+        request=Request(method="POST", url="https://example.com/upload"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"chunk1", b"chunk2"])),
+        key="stream_key",
+        id_=uuid.UUID(int=0),
+    )
+
+    for _ in entry.response._iter_stream():
+        ...
+
+    entries = storage.get_entries("stream_key")
+    assert len(entries) == 1
+    assert entries[0].cache_key == b"stream_key"
+
+
+def test_get_entries() -> None:
+    """Test retrieving entries by cache key."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    e1 = storage.create_entry(
+        request=Request(method="GET", url="https://example.com/1"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"response1"])),
+        key="shared_key",
+        id_=uuid.UUID(int=1),
+    )
+    e1.response.read()
+
+    e2 = storage.create_entry(
+        request=Request(method="GET", url="https://example.com/2"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"response2"])),
+        key="shared_key",
+        id_=uuid.UUID(int=2),
+    )
+    e2.response.read()
+
+    entries = storage.get_entries("shared_key")
+    assert len(entries) == 2
+    assert all(entry.cache_key == b"shared_key" for entry in entries)
+
+
+def test_multiple_entries_same_key() -> None:
+    """Test creating multiple entries with the same cache key."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    e1 = storage.create_entry(
+        request=Request(method="GET", url="https://example.com/1"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"response1"])),
+        key="shared_key",
+        id_=uuid.UUID(int=3),
+    )
+    e1.response.read()
+
+    e2 = storage.create_entry(
+        request=Request(method="GET", url="https://example.com/2"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"response2"])),
+        key="shared_key",
+        id_=uuid.UUID(int=4),
+    )
+    e2.response.read()
+
+    entries = storage.get_entries("shared_key")
+    assert len(entries) == 2
+    assert all(entry.response is not None for entry in entries)
+
+
+def test_multiple_entries_different_keys() -> None:
+    """Test that entries with different keys are properly isolated."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    for i in range(3):
+        entry = storage.create_entry(
+            request=Request(method="GET", url=f"https://example.com/{i}"),
+            response=Response(status_code=200, stream=make_sync_iterator([f"data{i}".encode()])),
+            key=f"key_{i}",
+            id_=uuid.UUID(int=9 + i),
+        )
+        for _ in entry.response._iter_stream():
+            ...
+
+    for i in range(3):
+        entries = storage.get_entries(f"key_{i}")
+        assert len(entries) == 1
+        assert entries[0].request.url == f"https://example.com/{i}"
+
+
+def test_update_entry() -> None:
+    """Test updating an existing entry with a callable."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"original"])),
+        key="original_key",
+        id_=uuid.UUID(int=5),
+    )
+    entry.response.read()
+
+    def updater(pair):
+        return replace(pair, cache_key=b"updated_key")
+
+    result = storage.update_entry(entry.id, updater)
+    assert result is not None
+    assert result.cache_key == b"updated_key"
+
+    entries = storage.get_entries("updated_key")
+    assert len(entries) == 1
+    assert entries[0].cache_key == b"updated_key"
+
+
+def test_update_entry_with_new_entry() -> None:
+    """Test updating an entry by providing a new entry directly."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"data"])),
+        key="key1",
+        id_=uuid.UUID(int=6),
+    )
+    entry.response.read()
+
+    new_entry = replace(entry, cache_key=b"key2")
+    result = storage.update_entry(entry.id, new_entry)
+
+    assert result is not None
+    assert result.cache_key == b"key2"
+
+
+def test_update_entry_preserves_ttl() -> None:
+    """Test that update_entry preserves the remaining Redis TTL rather than refreshing it."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    with travel(datetime(2024, 1, 1, 0, 0, 0, tzinfo=ZoneInfo("UTC"))):
+        entry = storage.create_entry(
+            request=Request(method="GET", url="https://example.com", metadata={"hishel_ttl": 60}),
+            response=Response(status_code=200, stream=make_sync_iterator([b"data"])),
+            key="test_key",
+            id_=uuid.UUID(int=15),
+        )
+        entry.response.read()
+
+    # Advance 30s — half the effective TTL consumed.
+    # Safe TTL was (60 + 180) * 1000 = 240_000 ms; ~210_000 ms should remain.
+    with travel(datetime(2024, 1, 1, 0, 0, 30, tzinfo=ZoneInfo("UTC"))):
+        storage.update_entry(
+            entry.id,
+            lambda e: replace(e, cache_key=b"renamed_key"),
+        )
+        pttl = client.pttl(f"hishel:entry:{entry.id.hex}")
+        # Should be roughly 210s remaining, definitely not reset to the full 240s
+        assert 200_000 < pttl < 220_000
+
+
+def test_refresh_entry_ttl() -> None:
+    """Test that refresh_entry_ttl resets all key TTLs to the full safe TTL."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client, soft_delete_ttl=180)
+
+    with travel(datetime(2024, 1, 1, 0, 0, 0, tzinfo=ZoneInfo("UTC"))):
+        entry = storage.create_entry(
+            request=Request(method="GET", url="https://example.com", metadata={"hishel_ttl": 60}),
+            response=Response(status_code=200, stream=make_sync_iterator([b"data"])),
+            key="test_key",
+            id_=uuid.UUID(int=15),
+        )
+        entry.response.read()
+
+    # Advance 30s — half the effective TTL consumed.
+    with travel(datetime(2024, 1, 1, 0, 0, 30, tzinfo=ZoneInfo("UTC"))):
+        storage.refresh_entry_ttl(entry.id)
+
+        hex_id = entry.id.hex
+        # Safe TTL = (60 + 180) * 1000 = 240_000 ms; all four keys should be reset to it.
+        for suffix in ("entry", "stream", "stream_done"):
+            pttl = client.pttl(f"hishel:{suffix}:{hex_id}")
+            assert 230_000 < pttl <= 240_000, f"key {suffix} not refreshed (pttl={pttl})"
+
+        idx_pttl = client.pttl("hishel:idx:test_key")
+        assert 230_000 < idx_pttl <= 240_000
+
+
+def test_refresh_nonexistent_entry_ttl() -> None:
+    """Test that refresh_entry_ttl on a missing entry is a no-op."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    # Should not raise
+    storage.refresh_entry_ttl(uuid.UUID(int=999))
+
+
+def test_remove_entry() -> None:
+    """Test that remove_entry soft-deletes the entry and hides it from get_entries."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"data"])),
+        key="test_key",
+        id_=uuid.UUID(int=7),
+    )
+    entry.response.read()
+
+    storage.remove_entry(entry.id)
+
+    hex_id = entry.id.hex
+    # Keys still exist (soft delete, not hard delete)
+    assert client.exists(f"hishel:entry:{hex_id}") == 1
+    # TTL on the entry key has been shrunk to soft_delete_ttl (default 180s)
+    assert 0 < client.ttl(f"hishel:entry:{hex_id}") <= 180
+    # Soft-deleted entry is invisible to get_entries
+    assert storage.get_entries("test_key") == []
+
+
+def test_remove_entry_custom_soft_delete_ttl() -> None:
+    """Test that a custom soft_delete_ttl is applied to Redis keys after remove_entry."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client, soft_delete_ttl=60)
+
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"data"])),
+        key="test_key",
+        id_=uuid.UUID(int=70),
+    )
+    entry.response.read()
+
+    storage.remove_entry(entry.id)
+
+    hex_id = entry.id.hex
+    assert 0 < client.ttl(f"hishel:entry:{hex_id}") <= 60
+
+
+def test_stream_persistence() -> None:
+    """Test that streams are properly saved and retrieved."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    response_chunks = [b"resp1", b"resp2"]
+
+    entry = storage.create_entry(
+        request=Request(method="POST", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator(response_chunks)),
+        key="stream_test",
+        id_=uuid.UUID(int=8),
+    )
+
+    for _ in entry.response._iter_stream():
+        ...
+
+    entries = storage.get_entries("stream_test")
+    assert len(entries) == 1
+
+    retrieved_chunks = []
+    for chunk in entries[0].response._iter_stream():
+        retrieved_chunks.append(chunk)
+
+    assert retrieved_chunks == response_chunks
+
+
+def test_remove_nonexistent_entry() -> None:
+    """Test that removing a non-existent entry doesn't raise an error."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    storage.remove_entry(uuid.UUID(int=999))
+
+
+def test_update_nonexistent_entry() -> None:
+    """Test that updating a non-existent entry returns None."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    result = storage.update_entry(uuid.UUID(int=999), lambda p: replace(p, cache_key=b"new_key"))
+    assert result is None
+
+
+def test_close_connection() -> None:
+    """Test that close() calls close() on the underlying async Redis client."""
+    mock_client = MagicMock()
+    mock_client.close = MagicMock()
+    storage = RedisStorage(client=mock_client)
+
+    storage.close()
+
+    mock_client.close.assert_called_once()
+
+
+def test_incomplete_entries() -> None:
+    """Test that entries with an incomplete stream are excluded from get_entries."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"chunk1", b"chunk2"])),
+        key="incomplete_key",
+        id_=uuid.UUID(int=10),
+    )
+
+    assert isinstance(entry.response.stream, Iterator)
+    entry.response.stream.__next__()
+
+    entries = storage.get_entries("incomplete_key")
+    assert len(entries) == 0
+
+
+def test_soft_deleted_entries() -> None:
+    """Test that entries marked as soft-deleted are excluded from get_entries."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"data"])),
+        key="soft_deleted_key",
+        id_=uuid.UUID(int=12),
+    )
+    entry.response.read()
+
+    storage.update_entry(entry.id, storage.mark_pair_as_deleted)
+
+    entries = storage.get_entries("soft_deleted_key")
+    assert len(entries) == 0
+
+
+def test_custom_ttl() -> None:
+    """Test that hishel_ttl in request metadata overrides default_ttl for expiry checks."""
+    client = fakeredis.FakeRedis()
+    # storage.ttl=3600 sets the default. hishel_ttl=1 overrides it to expire the entry sooner.
+    storage = RedisStorage(client=client, ttl=3600)
+
+    with travel(datetime(2024, 1, 1, 0, 0, 0, tzinfo=ZoneInfo("UTC"))):
+        entry = storage.create_entry(
+            request=Request(method="GET", url="https://example.com", metadata={"hishel_ttl": 1}),
+            response=Response(status_code=200, stream=make_sync_iterator([b"data"])),
+            key="test_key",
+            id_=uuid.UUID(int=13),
+        )
+        entry.response.read()
+
+    with travel(datetime(2024, 1, 1, 0, 0, 2, tzinfo=ZoneInfo("UTC"))):
+        entries = storage.get_entries("test_key")
+        assert len(entries) == 0
+
+
+def test_hishel_ttl_sets_redis_key_expiry() -> None:
+    """Test that hishel_ttl sets the Redis key TTL to effective_ttl + soft_delete_ttl."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client, soft_delete_ttl=180)
+
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com", metadata={"hishel_ttl": 42}),
+        response=Response(status_code=200, stream=make_sync_iterator([b"data"])),
+        key="test_key",
+        id_=uuid.UUID(int=14),
+    )
+    entry.response.read()
+
+    hex_id = entry.id.hex
+    entry_pttl = client.pttl(f"hishel:entry:{hex_id}")
+    assert isinstance(entry_pttl, int)
+    # Safe TTL = (42 + 180) * 1000 = 222_000 ms
+    assert 0 < entry_pttl <= 222_000
+    # And it should be meaningfully larger than the bare effective TTL,
+    # confirming the soft-delete buffer is being applied.
+    assert entry_pttl > 42_000
+
+
+def test_max_stream_size_aborts_caching() -> None:
+    """Test that exceeding max_stream_size drops partial stream data and skips caching."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client, max_stream_size=8)
+
+    response_chunks = [b"chunk1", b"chunk2", b"chunk3"]
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator(response_chunks)),
+        key="oversized_key",
+        id_=uuid.UUID(int=0),
+    )
+
+    yielded = list(entry.response._iter_stream())
+    assert yielded == response_chunks
+
+    hex_id = entry.id.hex
+    assert client.exists(f"hishel:stream:{hex_id}") == 0
+    assert client.exists(f"hishel:stream_done:{hex_id}") == 0
+    assert storage.get_entries("oversized_key") == []
+
+
+def test_max_stream_size_within_limit_caches_normally() -> None:
+    """Test that streams within max_stream_size are cached as usual."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client, max_stream_size=64)
+
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"small", b"data"])),
+        key="ok_key",
+        id_=uuid.UUID(int=0),
+    )
+    entry.response.read()
+
+    entries = storage.get_entries("ok_key")
+    assert len(entries) == 1
+
+
+def test_custom_prefix() -> None:
+    """Test checking custom redis key prefix."""
+    client = fakeredis.FakeRedis()
+    key_prefix = "a_key_prefix"
+    storage = RedisStorage(client=client, key_prefix=key_prefix)
+
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"response data"])),
+        key="test_key",
+        id_=uuid.UUID(int=0),
+    )
+
+    for _ in entry.response._iter_stream():
+        ...
+
+    hex_id = entry.id.hex
+    assert client.exists(f"{key_prefix}:entry:{hex_id}") == 1
+    assert client.exists(f"{key_prefix}:stream:{hex_id}") == 1
+    assert client.exists(f"{key_prefix}:stream_done:{hex_id}") == 1

--- a/tests/_core/_sync/test_redis_storage.py
+++ b/tests/_core/_sync/test_redis_storage.py
@@ -1,0 +1,483 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import replace
+from datetime import datetime
+from typing import Iterator
+from unittest.mock import MagicMock
+from zoneinfo import ZoneInfo
+
+import fakeredis
+import pytest
+from time_machine import travel
+
+from hishel import Request, Response
+from hishel._core._storages._sync_redis import RedisStorage
+from hishel._utils import make_sync_iterator
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    # redis is asyncio-only; restrict async tests to asyncio backend
+    return "asyncio"
+
+
+def test_add_entry() -> None:
+    """Test adding a complete entry with request and response."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"response data"])),
+        key="test_key",
+        id_=uuid.UUID(int=0),
+    )
+
+    for _ in entry.response._iter_stream():
+        ...
+
+    entries = storage.get_entries("test_key")
+    assert len(entries) == 1
+    assert entries[0].cache_key == b"test_key"
+
+
+def test_add_entry_with_stream() -> None:
+    """Test adding an entry with a multi-chunk streaming response body."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    entry = storage.create_entry(
+        request=Request(method="POST", url="https://example.com/upload"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"chunk1", b"chunk2"])),
+        key="stream_key",
+        id_=uuid.UUID(int=0),
+    )
+
+    for _ in entry.response._iter_stream():
+        ...
+
+    entries = storage.get_entries("stream_key")
+    assert len(entries) == 1
+    assert entries[0].cache_key == b"stream_key"
+
+
+def test_get_entries() -> None:
+    """Test retrieving entries by cache key."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    e1 = storage.create_entry(
+        request=Request(method="GET", url="https://example.com/1"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"response1"])),
+        key="shared_key",
+        id_=uuid.UUID(int=1),
+    )
+    e1.response.read()
+
+    e2 = storage.create_entry(
+        request=Request(method="GET", url="https://example.com/2"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"response2"])),
+        key="shared_key",
+        id_=uuid.UUID(int=2),
+    )
+    e2.response.read()
+
+    entries = storage.get_entries("shared_key")
+    assert len(entries) == 2
+    assert all(entry.cache_key == b"shared_key" for entry in entries)
+
+
+def test_multiple_entries_same_key() -> None:
+    """Test creating multiple entries with the same cache key."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    e1 = storage.create_entry(
+        request=Request(method="GET", url="https://example.com/1"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"response1"])),
+        key="shared_key",
+        id_=uuid.UUID(int=3),
+    )
+    e1.response.read()
+
+    e2 = storage.create_entry(
+        request=Request(method="GET", url="https://example.com/2"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"response2"])),
+        key="shared_key",
+        id_=uuid.UUID(int=4),
+    )
+    e2.response.read()
+
+    entries = storage.get_entries("shared_key")
+    assert len(entries) == 2
+    assert all(entry.response is not None for entry in entries)
+
+
+def test_multiple_entries_different_keys() -> None:
+    """Test that entries with different keys are properly isolated."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    for i in range(3):
+        entry = storage.create_entry(
+            request=Request(method="GET", url=f"https://example.com/{i}"),
+            response=Response(status_code=200, stream=make_sync_iterator([f"data{i}".encode()])),
+            key=f"key_{i}",
+            id_=uuid.UUID(int=9 + i),
+        )
+        for _ in entry.response._iter_stream():
+            ...
+
+    for i in range(3):
+        entries = storage.get_entries(f"key_{i}")
+        assert len(entries) == 1
+        assert entries[0].request.url == f"https://example.com/{i}"
+
+
+def test_update_entry() -> None:
+    """Test updating an existing entry with a callable."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"original"])),
+        key="original_key",
+        id_=uuid.UUID(int=5),
+    )
+    entry.response.read()
+
+    def updater(pair):
+        return replace(pair, cache_key=b"updated_key")
+
+    result = storage.update_entry(entry.id, updater)
+    assert result is not None
+    assert result.cache_key == b"updated_key"
+
+    entries = storage.get_entries("updated_key")
+    assert len(entries) == 1
+    assert entries[0].cache_key == b"updated_key"
+
+
+def test_update_entry_with_new_entry() -> None:
+    """Test updating an entry by providing a new entry directly."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"data"])),
+        key="key1",
+        id_=uuid.UUID(int=6),
+    )
+    entry.response.read()
+
+    new_entry = replace(entry, cache_key=b"key2")
+    result = storage.update_entry(entry.id, new_entry)
+
+    assert result is not None
+    assert result.cache_key == b"key2"
+
+
+def test_update_entry_preserves_ttl() -> None:
+    """Test that update_entry preserves the remaining Redis TTL rather than refreshing it."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    with travel(datetime(2024, 1, 1, 0, 0, 0, tzinfo=ZoneInfo("UTC"))):
+        entry = storage.create_entry(
+            request=Request(method="GET", url="https://example.com", metadata={"hishel_ttl": 60}),
+            response=Response(status_code=200, stream=make_sync_iterator([b"data"])),
+            key="test_key",
+            id_=uuid.UUID(int=15),
+        )
+        entry.response.read()
+
+    # Advance 30s — half the effective TTL consumed.
+    # Safe TTL was (60 + 180) * 1000 = 240_000 ms; ~210_000 ms should remain.
+    with travel(datetime(2024, 1, 1, 0, 0, 30, tzinfo=ZoneInfo("UTC"))):
+        storage.update_entry(
+            entry.id,
+            lambda e: replace(e, cache_key=b"renamed_key"),
+        )
+        pttl = client.pttl(f"hishel:entry:{entry.id.hex}")
+        # Should be roughly 210s remaining, definitely not reset to the full 240s
+        assert 200_000 < pttl < 220_000
+
+
+def test_refresh_entry_ttl() -> None:
+    """Test that refresh_entry_ttl resets all key TTLs to the full safe TTL."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client, soft_delete_ttl=180)
+
+    with travel(datetime(2024, 1, 1, 0, 0, 0, tzinfo=ZoneInfo("UTC"))):
+        entry = storage.create_entry(
+            request=Request(method="GET", url="https://example.com", metadata={"hishel_ttl": 60}),
+            response=Response(status_code=200, stream=make_sync_iterator([b"data"])),
+            key="test_key",
+            id_=uuid.UUID(int=15),
+        )
+        entry.response.read()
+
+    # Advance 30s — half the effective TTL consumed.
+    with travel(datetime(2024, 1, 1, 0, 0, 30, tzinfo=ZoneInfo("UTC"))):
+        storage.refresh_entry_ttl(entry.id)
+
+        hex_id = entry.id.hex
+        # Safe TTL = (60 + 180) * 1000 = 240_000 ms; all four keys should be reset to it.
+        for suffix in ("entry", "stream", "stream_done"):
+            pttl = client.pttl(f"hishel:{suffix}:{hex_id}")
+            assert 230_000 < pttl <= 240_000, f"key {suffix} not refreshed (pttl={pttl})"
+
+        idx_pttl = client.pttl("hishel:idx:test_key")
+        assert 230_000 < idx_pttl <= 240_000
+
+
+def test_refresh_nonexistent_entry_ttl() -> None:
+    """Test that refresh_entry_ttl on a missing entry is a no-op."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    # Should not raise
+    storage.refresh_entry_ttl(uuid.UUID(int=999))
+
+
+def test_remove_entry() -> None:
+    """Test that remove_entry soft-deletes the entry and hides it from get_entries."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"data"])),
+        key="test_key",
+        id_=uuid.UUID(int=7),
+    )
+    entry.response.read()
+
+    storage.remove_entry(entry.id)
+
+    hex_id = entry.id.hex
+    # Keys still exist (soft delete, not hard delete)
+    assert client.exists(f"hishel:entry:{hex_id}") == 1
+    # TTL on the entry key has been shrunk to soft_delete_ttl (default 180s)
+    assert 0 < client.ttl(f"hishel:entry:{hex_id}") <= 180
+    # Soft-deleted entry is invisible to get_entries
+    assert storage.get_entries("test_key") == []
+
+
+def test_remove_entry_custom_soft_delete_ttl() -> None:
+    """Test that a custom soft_delete_ttl is applied to Redis keys after remove_entry."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client, soft_delete_ttl=60)
+
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"data"])),
+        key="test_key",
+        id_=uuid.UUID(int=70),
+    )
+    entry.response.read()
+
+    storage.remove_entry(entry.id)
+
+    hex_id = entry.id.hex
+    assert 0 < client.ttl(f"hishel:entry:{hex_id}") <= 60
+
+
+def test_stream_persistence() -> None:
+    """Test that streams are properly saved and retrieved."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    response_chunks = [b"resp1", b"resp2"]
+
+    entry = storage.create_entry(
+        request=Request(method="POST", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator(response_chunks)),
+        key="stream_test",
+        id_=uuid.UUID(int=8),
+    )
+
+    for _ in entry.response._iter_stream():
+        ...
+
+    entries = storage.get_entries("stream_test")
+    assert len(entries) == 1
+
+    retrieved_chunks = []
+    for chunk in entries[0].response._iter_stream():
+        retrieved_chunks.append(chunk)
+
+    assert retrieved_chunks == response_chunks
+
+
+def test_remove_nonexistent_entry() -> None:
+    """Test that removing a non-existent entry doesn't raise an error."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    storage.remove_entry(uuid.UUID(int=999))
+
+
+def test_update_nonexistent_entry() -> None:
+    """Test that updating a non-existent entry returns None."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    result = storage.update_entry(uuid.UUID(int=999), lambda p: replace(p, cache_key=b"new_key"))
+    assert result is None
+
+
+def test_close_connection() -> None:
+    """Test that close() calls close() on the underlying async Redis client."""
+    mock_client = MagicMock()
+    mock_client.close = MagicMock()
+    storage = RedisStorage(client=mock_client)
+
+    storage.close()
+
+    mock_client.close.assert_called_once()
+
+
+def test_incomplete_entries() -> None:
+    """Test that entries with an incomplete stream are excluded from get_entries."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"chunk1", b"chunk2"])),
+        key="incomplete_key",
+        id_=uuid.UUID(int=10),
+    )
+
+    assert isinstance(entry.response.stream, Iterator)
+    entry.response.stream.__next__()
+
+    entries = storage.get_entries("incomplete_key")
+    assert len(entries) == 0
+
+
+def test_soft_deleted_entries() -> None:
+    """Test that entries marked as soft-deleted are excluded from get_entries."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client)
+
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"data"])),
+        key="soft_deleted_key",
+        id_=uuid.UUID(int=12),
+    )
+    entry.response.read()
+
+    storage.update_entry(entry.id, storage.mark_pair_as_deleted)
+
+    entries = storage.get_entries("soft_deleted_key")
+    assert len(entries) == 0
+
+
+def test_custom_ttl() -> None:
+    """Test that hishel_ttl in request metadata overrides default_ttl for expiry checks."""
+    client = fakeredis.FakeRedis()
+    # storage.ttl=3600 sets the default. hishel_ttl=1 overrides it to expire the entry sooner.
+    storage = RedisStorage(client=client, ttl=3600)
+
+    with travel(datetime(2024, 1, 1, 0, 0, 0, tzinfo=ZoneInfo("UTC"))):
+        entry = storage.create_entry(
+            request=Request(method="GET", url="https://example.com", metadata={"hishel_ttl": 1}),
+            response=Response(status_code=200, stream=make_sync_iterator([b"data"])),
+            key="test_key",
+            id_=uuid.UUID(int=13),
+        )
+        entry.response.read()
+
+    with travel(datetime(2024, 1, 1, 0, 0, 2, tzinfo=ZoneInfo("UTC"))):
+        entries = storage.get_entries("test_key")
+        assert len(entries) == 0
+
+
+def test_hishel_ttl_sets_redis_key_expiry() -> None:
+    """Test that hishel_ttl sets the Redis key TTL to effective_ttl + soft_delete_ttl."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client, soft_delete_ttl=180)
+
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com", metadata={"hishel_ttl": 42}),
+        response=Response(status_code=200, stream=make_sync_iterator([b"data"])),
+        key="test_key",
+        id_=uuid.UUID(int=14),
+    )
+    entry.response.read()
+
+    hex_id = entry.id.hex
+    entry_pttl = client.pttl(f"hishel:entry:{hex_id}")
+    assert isinstance(entry_pttl, int)
+    # Safe TTL = (42 + 180) * 1000 = 222_000 ms
+    assert 0 < entry_pttl <= 222_000
+    # And it should be meaningfully larger than the bare effective TTL,
+    # confirming the soft-delete buffer is being applied.
+    assert entry_pttl > 42_000
+
+
+def test_max_stream_size_aborts_caching() -> None:
+    """Test that exceeding max_stream_size drops partial stream data and skips caching."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client, max_stream_size=8)
+
+    response_chunks = [b"chunk1", b"chunk2", b"chunk3"]
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator(response_chunks)),
+        key="oversized_key",
+        id_=uuid.UUID(int=0),
+    )
+
+    yielded = list(entry.response._iter_stream())
+    assert yielded == response_chunks
+
+    hex_id = entry.id.hex
+    assert client.exists(f"hishel:stream:{hex_id}") == 0
+    assert client.exists(f"hishel:stream_done:{hex_id}") == 0
+    assert storage.get_entries("oversized_key") == []
+
+
+def test_max_stream_size_within_limit_caches_normally() -> None:
+    """Test that streams within max_stream_size are cached as usual."""
+    client = fakeredis.FakeRedis()
+    storage = RedisStorage(client=client, max_stream_size=64)
+
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"small", b"data"])),
+        key="ok_key",
+        id_=uuid.UUID(int=0),
+    )
+    entry.response.read()
+
+    entries = storage.get_entries("ok_key")
+    assert len(entries) == 1
+
+
+def test_custom_prefix() -> None:
+    """Test checking custom redis key prefix."""
+    client = fakeredis.FakeRedis()
+    key_prefix = "a_key_prefix"
+    storage = RedisStorage(client=client, key_prefix=key_prefix)
+
+    entry = storage.create_entry(
+        request=Request(method="GET", url="https://example.com"),
+        response=Response(status_code=200, stream=make_sync_iterator([b"response data"])),
+        key="test_key",
+        id_=uuid.UUID(int=0),
+    )
+
+    for _ in entry.response._iter_stream():
+        ...
+
+    hex_id = entry.id.hex
+    assert client.exists(f"{key_prefix}:entry:{hex_id}") == 1
+    assert client.exists(f"{key_prefix}:stream:{hex_id}") == 1
+    assert client.exists(f"{key_prefix}:stream_done:{hex_id}") == 1

--- a/uv.lock
+++ b/uv.lock
@@ -61,6 +61,15 @@ wheels = [
 ]
 
 [[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -547,6 +556,20 @@ wheels = [
 ]
 
 [[package]]
+name = "fakeredis"
+version = "2.35.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "redis" },
+    { name = "sortedcontainers" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/50/b748233c02fa77e5105238190cc9bb58b852eb1c8b1d0763230d3a5b745a/fakeredis-2.35.1.tar.gz", hash = "sha256:5bae5eba7b9d93cb968944ac40936373cf2397ff71667d4b595df65c3d2e413f", size = 189118, upload-time = "2026-04-12T17:05:58.539Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/27/b8b057a23f7777177e92d3a602fd866751b6b45014964548997e92e048fd/fakeredis-2.35.1-py3-none-any.whl", hash = "sha256:67d97e11f562b7870e11e5c30cf182270bfb2dd37f6707dba47cc6d91628d1b9", size = 129678, upload-time = "2026-04-12T17:05:56.86Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.136.0"
 source = { registry = "https://pypi.org/simple" }
@@ -850,6 +873,9 @@ httpx = [
     { name = "anysqlite" },
     { name = "httpx" },
 ]
+redis = [
+    { name = "redis" },
+]
 requests = [
     { name = "requests" },
 ]
@@ -859,6 +885,7 @@ dev = [
     { name = "anyio" },
     { name = "anysqlite" },
     { name = "coverage" },
+    { name = "fakeredis" },
     { name = "fastapi", extra = ["standard"] },
     { name = "hatch" },
     { name = "inline-snapshot" },
@@ -872,11 +899,13 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-icdiff" },
+    { name = "redis" },
     { name = "ruff" },
     { name = "time-machine" },
     { name = "trio" },
     { name = "types-boto3" },
     { name = "types-pyyaml" },
+    { name = "types-redis" },
     { name = "types-requests" },
     { name = "zipp" },
 ]
@@ -890,16 +919,18 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'fastapi'", specifier = ">=0.119.1" },
     { name = "httpx", marker = "extra == 'httpx'", specifier = ">=0.28.1" },
     { name = "msgpack", specifier = ">=1.1.2" },
+    { name = "redis", marker = "extra == 'redis'", specifier = ">=7.0.0" },
     { name = "requests", marker = "extra == 'requests'", specifier = ">=2.32.5" },
     { name = "typing-extensions", specifier = ">=4.14.1" },
 ]
-provides-extras = ["async", "requests", "httpx", "fastapi"]
+provides-extras = ["async", "requests", "httpx", "fastapi", "redis"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "anyio", specifier = "==4.12.1" },
     { name = "anysqlite", specifier = ">=0.0.5" },
     { name = "coverage", specifier = "==7.10.7" },
+    { name = "fakeredis", specifier = ">=2.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.119.1" },
     { name = "hatch", specifier = "==1.15.1" },
     { name = "inline-snapshot", specifier = ">=0.28.0" },
@@ -913,11 +944,13 @@ dev = [
     { name = "pytest", specifier = "==8.4.2" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-icdiff", specifier = ">=0.9" },
+    { name = "redis", specifier = ">=7.0.0" },
     { name = "ruff", specifier = "==0.14.14" },
     { name = "time-machine", specifier = ">=2.19.0" },
     { name = "trio", specifier = "==0.31.0" },
     { name = "types-boto3", specifier = "==1.42.39" },
     { name = "types-pyyaml", specifier = "==6.0.12.20250915" },
+    { name = "types-redis", specifier = ">=4.6.0.20241004" },
     { name = "types-requests", specifier = ">=2.31.0.6" },
     { name = "zipp", specifier = ">=3.19.1" },
 ]
@@ -2139,6 +2172,18 @@ wheels = [
 ]
 
 [[package]]
+name = "redis"
+version = "7.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/7f/3759b1d0d72b7c92f0d70ffd9dc962b7b7b5ee74e135f9d7d8ab06b8a318/redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad", size = 4943913, upload-time = "2026-03-24T09:14:37.53Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/3a/95deec7db1eb53979973ebd156f3369a72732208d1391cd2e5d127062a32/redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec", size = 409772, upload-time = "2026-03-24T09:14:35.968Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2634,12 +2679,50 @@ wheels = [
 ]
 
 [[package]]
+name = "types-cffi"
+version = "2.0.0.20260408"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "types-setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/67/eb4ef3408fdc0b4e5af38b30c0e6ad4663b41bdae9fb85a9f09a8db61a99/types_cffi-2.0.0.20260408.tar.gz", hash = "sha256:aa8b9c456ab715c079fc655929811f21f331bfb940f4a821987c581bf4e36230", size = 17541, upload-time = "2026-04-08T04:36:03.918Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/a3/7fbd93ededcc7c77e9e5948b9794161733ebdbf618a27965b1bea0e728a4/types_cffi-2.0.0.20260408-py3-none-any.whl", hash = "sha256:68bd296742b4ff7c0afe3547f50bd0acc55416ecf322ffefd2b7344ef6388a42", size = 20101, upload-time = "2026-04-08T04:36:02.995Z" },
+]
+
+[[package]]
+name = "types-pyopenssl"
+version = "24.1.0.20240722"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "types-cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/29/47a346550fd2020dac9a7a6d033ea03fccb92fa47c726056618cc889745e/types-pyOpenSSL-24.1.0.20240722.tar.gz", hash = "sha256:47913b4678a01d879f503a12044468221ed8576263c1540dcb0484ca21b08c39", size = 8458, upload-time = "2024-07-22T02:32:22.558Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/05/c868a850b6fbb79c26f5f299b768ee0adc1f9816d3461dcf4287916f655b/types_pyOpenSSL-24.1.0.20240722-py3-none-any.whl", hash = "sha256:6a7a5d2ec042537934cfb4c9d4deb0e16c4c6250b09358df1f083682fe6fda54", size = 7499, upload-time = "2024-07-22T02:32:21.232Z" },
+]
+
+[[package]]
 name = "types-pyyaml"
 version = "6.0.12.20250915"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522, upload-time = "2025-09-15T03:01:00.728Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338, upload-time = "2025-09-15T03:00:59.218Z" },
+]
+
+[[package]]
+name = "types-redis"
+version = "4.6.0.20241004"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "types-pyopenssl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/95/c054d3ac940e8bac4ca216470c80c26688a0e79e09f520a942bb27da3386/types-redis-4.6.0.20241004.tar.gz", hash = "sha256:5f17d2b3f9091ab75384153bfa276619ffa1cf6a38da60e10d5e6749cc5b902e", size = 49679, upload-time = "2024-10-04T02:43:59.224Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/82/7d25dce10aad92d2226b269bce2f85cfd843b4477cd50245d7d40ecf8f89/types_redis-4.6.0.20241004-py3-none-any.whl", hash = "sha256:ef5da68cb827e5f606c8f9c0b49eeee4c2669d6d97122f301d3a55dc6a63f6ed", size = 58737, upload-time = "2024-10-04T02:43:57.968Z" },
 ]
 
 [[package]]
@@ -2661,6 +2744,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fe/64/42689150509eb3e6e82b33ee3d89045de1592488842ddf23c56957786d05/types_s3transfer-0.16.0.tar.gz", hash = "sha256:b4636472024c5e2b62278c5b759661efeb52a81851cde5f092f24100b1ecb443", size = 13557, upload-time = "2025-12-08T08:13:09.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/98/27/e88220fe6274eccd3bdf95d9382918716d312f6f6cef6a46332d1ee2feff/types_s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:1c0cd111ecf6e21437cb410f5cddb631bfb2263b77ad973e79b9c6d0cb24e0ef", size = 19247, upload-time = "2025-12-08T08:13:08.426Z" },
+]
+
+[[package]]
+name = "types-setuptools"
+version = "82.0.0.20260408"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/12/3464b410c50420dd4674fa5fe9d3880711c1dbe1a06f5fe4960ee9067b9e/types_setuptools-82.0.0.20260408.tar.gz", hash = "sha256:036c68caf7e672a699f5ebbf914708d40644c14e05298bc49f7272be91cf43d3", size = 44861, upload-time = "2026-04-08T04:29:33.292Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/e1/46a4fc3ef03aabf5d18bac9df5cf37c6b02c3bddf3e05c3533f4b4588331/types_setuptools-82.0.0.20260408-py3-none-any.whl", hash = "sha256:ece0a215cdfa6463a65fd6f68bd940f39e455729300ddfe61cab1147ed1d2462", size = 68428, upload-time = "2026-04-08T04:29:32.175Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
closes #425 

Adds support for using Redis as a storage backend.

Redis supports the same streaming-based caching as the default SQLite implementation. This means you can cache large responses and read them without buffering them into memory. (In the case of Redis, the data is still stored in RAM - just on your database server instead of the client.)

For safety, it includes a `max_stream_size` setting (**10 MiB** by default), which prevents servers from overwhelming your Redis instance with very large streams. If you actually need to cache larger responses, you can reconfigure this limit.

Like the SQLite backend, Redis storage does not hard-delete expired entries. Instead, it soft-deletes them, allowing a buffer period for ongoing requests to finish using the cached stream. For Redis, this buffer is **3 minutes** by default and can be configured via `soft_delete_ttl`. In SQLite, it’s 1 hour, since disk storage is **much cheaper than RAM**

```
pip install hishel[redis,httpx]
```

```python
import redis

from hishel import RedisStorage
from hishel.httpx import SyncCacheClient

cl = SyncCacheClient(storage=RedisStorage(redis.Redis(host="localhost", port=6379, db=0)))
resp = cl.get("https://hishel.com")
resp = cl.get("https://hishel.com")  # from cache
print(resp.extensions)
```
