### PR TITLE
fix(spec): handle invalid expires date as expired

### DIFF
--- a/src/hishel/_core/_spec.py
+++ b/src/hishel/_core/_spec.py
@@ -350,7 +350,11 @@ def get_freshness_lifetime(response: Response, is_cache_shared: bool) -> Optiona
         expires_timestamp = parse_date(response.headers["expires"])
 
         if expires_timestamp is None:
-            raise RuntimeError("Cannot parse Expires header")  # pragma: nocover
+            # From the RFC
+            # A cache recipient MUST interpret invalid date formats, especially
+            # the value "0", as representing a time in the past (i.e.,
+            # "already expired").
+            return -1
 
         # Get the Date header or use current time as fallback
         date_timestamp = parse_date(response.headers["date"]) if "date" in response.headers else time.time()

--- a/tests/_core/spec/test_helper_functions.py
+++ b/tests/_core/spec/test_helper_functions.py
@@ -290,6 +290,27 @@ class TestGetFreshnessLifetime:
         # Should be approximately 2 hours (7200 seconds)
         assert 7190 <= lifetime <= 7210  # Allow small timing variance
 
+    def test_invalid_expires_header_is_expired(self) -> None:
+        """
+        Test: Expires header which is invalid is treated as already expired.
+
+        RFC 9111 Section 5.3: Expires
+        """
+        # Arrange
+        now = datetime.utcnow()
+        expires = "invalid-date"
+        date = now.strftime("%a, %d %b %Y %H:%M:%S GMT")
+
+        response = create_response(headers={"expires": expires, "date": date})
+
+        # Act
+        lifetime = get_freshness_lifetime(response, is_cache_shared=True)
+
+        # Assert
+        assert lifetime is not None
+        # Should be approximately 2 hours (7200 seconds)
+        assert lifetime < 0  # Invalid Expires treated as expired
+
     def test_max_age_takes_precedence_over_expires(self) -> None:
         """
         Test: max-age takes precedence over Expires.


### PR DESCRIPTION
This is the expected behavior per the RFC.

Fixes #467.

Thank you for such a wonderful library.