### PR TITLE
chore(test) Use time_machine.travel to freeze clock in flaky tests

### DIFF
--- a/tests/_core/spec/test_cache_miss.py
+++ b/tests/_core/spec/test_cache_miss.py
@@ -12,10 +12,11 @@ Test Categories:
 4. Edge cases and RFC 9111 compliance
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, Optional
 
 import pytest
+from time_machine import travel
 
 from hishel import Request, Response
 from hishel._core._headers import Headers
@@ -108,6 +109,7 @@ class TestTransitionToStoreAndUse:
         assert response.metadata.get("hishel_stored") is True
         assert response.metadata.get("hishel_from_cache") is False
 
+    @travel(datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc), tick=False)
     def test_response_with_expires_header_is_stored(self, default_options: CacheOptions) -> None:
         """
         Test: Response with Expires header is stored.
@@ -257,6 +259,7 @@ class TestTransitionToStoreAndUse:
         assert isinstance(next_state, StoreAndUse)
         assert response.metadata.get("hishel_revalidated") is True
 
+    @travel(datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc), tick=False)
     def test_response_with_multiple_caching_directives(self, default_options: CacheOptions) -> None:
         """
         Test: Response with multiple caching directives is stored.

--- a/tests/_core/spec/test_helper_functions.py
+++ b/tests/_core/spec/test_helper_functions.py
@@ -17,10 +17,11 @@ Test Categories:
 """
 
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, Optional
 
 import pytest
+from time_machine import travel
 
 from hishel import Entry, EntryMeta, Request, Response
 from hishel._core._headers import Headers
@@ -269,6 +270,7 @@ class TestGetFreshnessLifetime:
         assert shared_lifetime == 7200  # s-maxage for shared
         assert private_lifetime == 3600  # max-age for private
 
+    @travel(datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc), tick=False)
     def test_expires_header_provides_freshness(self) -> None:
         """
         Test: Expires header provides freshness lifetime.
@@ -286,10 +288,10 @@ class TestGetFreshnessLifetime:
         lifetime = get_freshness_lifetime(response, is_cache_shared=True)
 
         # Assert
-        assert lifetime is not None
-        # Should be approximately 2 hours (7200 seconds)
-        assert 7190 <= lifetime <= 7210  # Allow small timing variance
+        # Should be exactly 2 hours (7200 seconds) since the clock is frozen
+        assert lifetime == 7200
 
+    @travel(datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc), tick=False)
     def test_invalid_expires_header_is_expired(self) -> None:
         """
         Test: Expires header which is invalid is treated as already expired.
@@ -309,6 +311,7 @@ class TestGetFreshnessLifetime:
         # Assert
         assert lifetime is None or lifetime < 0  # Invalid Expires treated as expired
 
+    @travel(datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc), tick=False)
     def test_expires_header_missing_date(self) -> None:
         """
         Test: Expires header provides freshness lifetime even when Date header is missing.
@@ -325,9 +328,8 @@ class TestGetFreshnessLifetime:
         lifetime = get_freshness_lifetime(response, is_cache_shared=True)
 
         # Assert
-        assert lifetime is not None
-        # Should be approximately 2 hours (7200 seconds)
-        assert 7190 <= lifetime <= 7210  # Allow small timing variance
+        # Should be exactly 2 hours (7200 seconds) since the clock is frozen
+        assert lifetime == 7200
 
     def test_max_age_takes_precedence_over_expires(self) -> None:
         """
@@ -346,6 +348,7 @@ class TestGetFreshnessLifetime:
         # Assert
         assert lifetime == 3600  # max-age, not Expires
 
+    @travel(datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc), tick=False)
     def test_heuristic_freshness_when_no_explicit_expiration(self) -> None:
         """
         Test: Heuristic freshness is used when no explicit expiration exists.
@@ -360,9 +363,8 @@ class TestGetFreshnessLifetime:
         lifetime = get_freshness_lifetime(response, is_cache_shared=True)
 
         # Assert
-        assert lifetime is not None
-        # Should be ~10% of 10 days = 1 day = 86400 seconds
-        assert 80000 <= lifetime <= 90000
+        # Should be exactly 10% of 10 days = 1 day = 86400 seconds
+        assert lifetime == 86400
 
     def test_no_freshness_info_returns_none(self) -> None:
         """
@@ -466,6 +468,7 @@ class TestGetHeuristicFreshness:
     RFC 9111 Section 4.2.2: Calculating Heuristic Freshness
     """
 
+    @travel(datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc), tick=False)
     def test_heuristic_freshness_from_last_modified(self) -> None:
         """
         Test: Heuristic freshness calculated as 10% of age since Last-Modified.
@@ -485,9 +488,9 @@ class TestGetHeuristicFreshness:
 
         # Assert
         # 10% of 10 days = 1 day = 86400 seconds
-        assert freshness is not None
-        assert 80000 <= freshness <= 90000  # Allow timing variance
+        assert freshness == 86400
 
+    @travel(datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc), tick=False)
     def test_heuristic_freshness_capped_at_one_week(self) -> None:
         """
         Test: Heuristic freshness is capped at one week maximum.
@@ -533,6 +536,7 @@ class TestGetAge:
     RFC 9111 Section 4.2.3: Calculating Age
     """
 
+    @travel(datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc), tick=False)
     def test_age_calculation_from_date_header(self) -> None:
         """
         Test: Age is calculated from Date header.
@@ -550,8 +554,8 @@ class TestGetAge:
         age = get_age(response)
 
         # Assert
-        # Should be approximately 3600 seconds (1 hour)
-        assert 3590 <= age <= 3610
+        # Should be exactly 3600 seconds (1 hour) since the clock is frozen
+        assert age == 3600
 
     def test_age_is_zero_without_date_header(self) -> None:
         """
@@ -571,6 +575,7 @@ class TestGetAge:
         # Assert
         assert age == 0
 
+    @travel(datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc), tick=False)
     def test_age_is_zero_for_future_date(self) -> None:
         """
         Test: Age is 0 when Date is in the future (clock skew protection).

--- a/tests/_core/spec/test_idle_client.py
+++ b/tests/_core/spec/test_idle_client.py
@@ -13,10 +13,11 @@ Test Categories:
 """
 
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional
 
 import pytest
+from time_machine import travel
 
 from hishel import Entry, EntryMeta, Request, Response
 from hishel._core._headers import Headers
@@ -505,6 +506,7 @@ class TestTransitionToFromCache:
         assert selected_age >= 1000
         assert selected_age < 2000  # Should be closer to 1000 than 2000
 
+    @travel(datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc), tick=False)
     def test_age_header_updated_correctly(self, idle_client: IdleClient) -> None:
         """
         Test: Age header is calculated and updated correctly.
@@ -532,10 +534,9 @@ class TestTransitionToFromCache:
         # Assert
         assert isinstance(next_state, FromCache)
 
-        # Age should be at least the initial age
+        # Age should equal the initial age exactly since the clock is frozen
         age_value = int(next_state.entry.response.headers["age"])
-        assert age_value >= initial_age
-        assert age_value < initial_age + 5  # Shouldn't increase by more than a few seconds
+        assert age_value == initial_age
 
     def test_matching_vary_headers_allows_cache_hit(self, idle_client: IdleClient) -> None:
         """
@@ -790,6 +791,7 @@ class TestEdgeCasesAndCompliance:
     Tests for edge cases and specific RFC 9111 compliance scenarios.
     """
 
+    @travel(datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc), tick=False)
     def test_response_without_explicit_freshness_info(self, idle_client: IdleClient) -> None:
         """
         Test: Response without explicit freshness information.
@@ -913,6 +915,7 @@ class TestEdgeCasesAndCompliance:
         # Assert
         assert isinstance(next_state, FromCache)
 
+    @travel(datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc), tick=False)
     def test_age_close_to_zero_for_newly_generated_response(self, idle_client: IdleClient) -> None:
         """
         Test: Age should be close to zero for a freshly cached response.
@@ -933,7 +936,7 @@ class TestEdgeCasesAndCompliance:
         # Assert
         assert isinstance(next_state, FromCache)
         age_value = int(next_state.entry.response.headers["age"])
-        assert age_value < 10  # Should be very close to 0
+        assert age_value == 0  # Should be exactly 0 since the clock is frozen
 
     def test_sorting_handles_responses_without_date_header(self, idle_client: IdleClient) -> None:
         """


### PR DESCRIPTION
Generated with assistance from copilot and double-checked by a human!