### PR TITLE
feat: preserve serializable httpx response extensions

### DIFF
--- a/src/hishel/_async_httpx.py
+++ b/src/hishel/_async_httpx.py
@@ -40,6 +40,23 @@ SOCKET_OPTION = t.Union[
 # 128 KB
 CHUNK_SIZE = 131072
 
+# httpx response extensions that are safe to cache. Skip live transport
+# objects (network_stream) and per-connection identifiers (stream_id).
+KNOWN_HTTPX_RESPONSE_EXTENSIONS = frozenset({"http_version", "reason_phrase"})
+
+
+def _httpx_extensions_metadata(extensions: t.Mapping[str, t.Any]) -> dict[str, t.Any]:
+    httpx_meta = {key: val for key, val in extensions.items() if key in KNOWN_HTTPX_RESPONSE_EXTENSIONS}
+    return {"httpx": httpx_meta} if httpx_meta else {}
+
+
+def _httpx_extensions_from_metadata(metadata: t.Mapping[str, t.Any]) -> dict[str, t.Any]:
+    extras = dict(metadata)
+    httpx_meta = extras.pop("httpx", None)
+    if isinstance(httpx_meta, dict):
+        extras.update(httpx_meta)
+    return extras
+
 
 @overload
 def _internal_to_httpx(
@@ -68,7 +85,7 @@ def _internal_to_httpx(
             status_code=value.status_code,
             headers=value.headers,
             stream=_IteratorStream(value._aiter_stream()),
-            extensions=value.metadata,
+            extensions=_httpx_extensions_from_metadata(value.metadata),
         )
 
 
@@ -140,7 +157,7 @@ def _httpx_to_internal(
             status_code=value.status_code,
             headers=headers,
             stream=stream,
-            metadata={},
+            metadata=_httpx_extensions_metadata(value.extensions),
         )
 
 

--- a/src/hishel/_core/_storages/_packing.py
+++ b/src/hishel/_core/_storages/_packing.py
@@ -11,11 +11,7 @@ from hishel._core.models import EntryMeta, Request, Response
 
 
 def filter_out_hishel_metadata(data: Mapping[str, Any]) -> dict[str, Any]:
-    return {
-        k: v
-        for k, v in data.items()
-        if not (k.startswith("hishel_") and k not in {"hishel_ttl", "hishel_httpx"})
-    }
+    return {k: v for k, v in data.items() if not (k.startswith("hishel_") and k not in {"hishel_ttl", "hishel_httpx"})}
 
 
 if TYPE_CHECKING:

--- a/src/hishel/_sync_httpx.py
+++ b/src/hishel/_sync_httpx.py
@@ -40,6 +40,23 @@ SOCKET_OPTION = t.Union[
 # 128 KB
 CHUNK_SIZE = 131072
 
+# httpx response extensions that are safe to cache. Skip live transport
+# objects (network_stream) and per-connection identifiers (stream_id).
+KNOWN_HTTPX_RESPONSE_EXTENSIONS = frozenset({"http_version", "reason_phrase"})
+
+
+def _httpx_extensions_metadata(extensions: t.Mapping[str, t.Any]) -> dict[str, t.Any]:
+    httpx_meta = {key: val for key, val in extensions.items() if key in KNOWN_HTTPX_RESPONSE_EXTENSIONS}
+    return {"httpx": httpx_meta} if httpx_meta else {}
+
+
+def _httpx_extensions_from_metadata(metadata: t.Mapping[str, t.Any]) -> dict[str, t.Any]:
+    extras = dict(metadata)
+    httpx_meta = extras.pop("httpx", None)
+    if isinstance(httpx_meta, dict):
+        extras.update(httpx_meta)
+    return extras
+
 
 @overload
 def _internal_to_httpx(
@@ -68,7 +85,7 @@ def _internal_to_httpx(
             status_code=value.status_code,
             headers=value.headers,
             stream=_IteratorStream(value._iter_stream()),
-            extensions=value.metadata,
+            extensions=_httpx_extensions_from_metadata(value.metadata),
         )
 
 
@@ -140,7 +157,7 @@ def _httpx_to_internal(
             status_code=value.status_code,
             headers=headers,
             stream=stream,
-            metadata={},
+            metadata=_httpx_extensions_metadata(value.extensions),
         )
 
 

--- a/tests/test_async_httpx.py
+++ b/tests/test_async_httpx.py
@@ -41,6 +41,8 @@ async def test_simple_caching(caplog: pytest.LogCaptureFixture) -> None:
             "hishel_created_at": 1704067200.0,
             "hishel_revalidated": False,
             "hishel_stored": False,
+            "http_version": b"HTTP/1.1",
+            "reason_phrase": b"OK",
         }
     )
 
@@ -73,6 +75,8 @@ async def test_simple_caching_ignoring_spec(caplog: pytest.LogCaptureFixture) ->
             "hishel_created_at": 1704067200.0,
             "hishel_revalidated": False,
             "hishel_stored": False,
+            "http_version": b"HTTP/1.1",
+            "reason_phrase": b"OK",
         }
     )
 
@@ -119,3 +123,39 @@ async def test_encoded_content_caching() -> None:
         assert data == response_data
         assert response.headers.get("Content-Length") == str(len(data)) == str(len(response_data))
         assert response.headers.get("Content-Encoding") == "gzip"
+
+
+@pytest.mark.anyio
+async def test_httpx_response_extensions_are_preserved() -> None:
+    network_stream = object()
+    mocked_responses = [
+        httpx.Response(
+            200,
+            content=b"ok",
+            headers={"Cache-Control": "max-age=3600", "Content-Type": "text/plain"},
+            extensions={"http_version": b"HTTP/2", "network_stream": network_stream, "stream_id": 1},
+        )
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if not mocked_responses:
+            raise RuntimeError("No more mocked responses available")
+        return mocked_responses.pop(0)
+
+    client = AsyncCacheClient(
+        transport=AsyncCacheTransport(
+            next_transport=MockTransport(handler=handler),
+            storage=AsyncSqliteStorage(connection=await anysqlite.connect(":memory:", check_same_thread=False)),
+        ),
+    )
+
+    first = await client.get("https://localhost")
+    assert first.extensions["http_version"] == b"HTTP/2"
+    assert "network_stream" not in first.extensions
+    assert "stream_id" not in first.extensions
+
+    second = await client.get("https://localhost")
+    assert second.extensions["hishel_from_cache"] is True
+    assert second.extensions["http_version"] == b"HTTP/2"
+    assert "network_stream" not in second.extensions
+    assert "stream_id" not in second.extensions

--- a/tests/test_sync_httpx.py
+++ b/tests/test_sync_httpx.py
@@ -41,6 +41,8 @@ def test_simple_caching(caplog: pytest.LogCaptureFixture) -> None:
             "hishel_created_at": 1704067200.0,
             "hishel_revalidated": False,
             "hishel_stored": False,
+            "http_version": b"HTTP/1.1",
+            "reason_phrase": b"OK",
         }
     )
 
@@ -73,6 +75,8 @@ def test_simple_caching_ignoring_spec(caplog: pytest.LogCaptureFixture) -> None:
             "hishel_created_at": 1704067200.0,
             "hishel_revalidated": False,
             "hishel_stored": False,
+            "http_version": b"HTTP/1.1",
+            "reason_phrase": b"OK",
         }
     )
 
@@ -119,3 +123,39 @@ def test_encoded_content_caching() -> None:
         assert data == response_data
         assert response.headers.get("Content-Length") == str(len(data)) == str(len(response_data))
         assert response.headers.get("Content-Encoding") == "gzip"
+
+
+
+def test_httpx_response_extensions_are_preserved() -> None:
+    network_stream = object()
+    mocked_responses = [
+        httpx.Response(
+            200,
+            content=b"ok",
+            headers={"Cache-Control": "max-age=3600", "Content-Type": "text/plain"},
+            extensions={"http_version": b"HTTP/2", "network_stream": network_stream, "stream_id": 1},
+        )
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if not mocked_responses:
+            raise RuntimeError("No more mocked responses available")
+        return mocked_responses.pop(0)
+
+    client = SyncCacheClient(
+        transport=SyncCacheTransport(
+            next_transport=MockTransport(handler=handler),
+            storage=SyncSqliteStorage(connection=sqlite3.connect(":memory:", check_same_thread=False)),
+        ),
+    )
+
+    first = client.get("https://localhost")
+    assert first.extensions["http_version"] == b"HTTP/2"
+    assert "network_stream" not in first.extensions
+    assert "stream_id" not in first.extensions
+
+    second = client.get("https://localhost")
+    assert second.extensions["hishel_from_cache"] is True
+    assert second.extensions["http_version"] == b"HTTP/2"
+    assert "network_stream" not in second.extensions
+    assert "stream_id" not in second.extensions


### PR DESCRIPTION
Closes #438

Converting an httpx response into hishel's internal `Response` was dropping `extensions`, so `http_version` (and `reason_phrase`) never made it into cache. Cached replies then came back as HTTP/1.1 even when the origin used HTTP/2.

Following the approach from the issue: keep a whitelist under `metadata["httpx"]`, skip live objects like `network_stream`, and flatten those fields back onto the httpx response on the way out.