### PR TITLE
Don't rechunk httpx streams into 128KB buffers

### DIFF
--- a/src/hishel/_async_httpx.py
+++ b/src/hishel/_async_httpx.py
@@ -37,6 +37,7 @@ SOCKET_OPTION = t.Union[
     t.Tuple[int, int, None, int],
 ]
 
+
 @overload
 def _internal_to_httpx(
     value: Request,
@@ -114,9 +115,7 @@ def _httpx_to_internal(
             metadata=headers_metadata,
         )
     elif isinstance(value, httpx.Response):
-        stream = (
-            make_async_iterator([value.content]) if value.is_stream_consumed else value.aiter_raw()
-        )
+        stream = make_async_iterator([value.content]) if value.is_stream_consumed else value.aiter_raw()
 
         if value.is_stream_consumed and "content-encoding" in value.headers:
             # If the stream was consumed and we don't know about

--- a/src/hishel/_async_httpx.py
+++ b/src/hishel/_async_httpx.py
@@ -37,10 +37,6 @@ SOCKET_OPTION = t.Union[
     t.Tuple[int, int, None, int],
 ]
 
-# 128 KB
-CHUNK_SIZE = 131072
-
-
 @overload
 def _internal_to_httpx(
     value: Request,
@@ -119,7 +115,7 @@ def _httpx_to_internal(
         )
     elif isinstance(value, httpx.Response):
         stream = (
-            make_async_iterator([value.content]) if value.is_stream_consumed else value.aiter_raw(chunk_size=CHUNK_SIZE)
+            make_async_iterator([value.content]) if value.is_stream_consumed else value.aiter_raw()
         )
 
         if value.is_stream_consumed and "content-encoding" in value.headers:

--- a/src/hishel/_sync_httpx.py
+++ b/src/hishel/_sync_httpx.py
@@ -37,10 +37,6 @@ SOCKET_OPTION = t.Union[
     t.Tuple[int, int, None, int],
 ]
 
-# 128 KB
-CHUNK_SIZE = 131072
-
-
 @overload
 def _internal_to_httpx(
     value: Request,
@@ -119,7 +115,7 @@ def _httpx_to_internal(
         )
     elif isinstance(value, httpx.Response):
         stream = (
-            make_sync_iterator([value.content]) if value.is_stream_consumed else value.iter_raw(chunk_size=CHUNK_SIZE)
+            make_sync_iterator([value.content]) if value.is_stream_consumed else value.iter_raw()
         )
 
         if value.is_stream_consumed and "content-encoding" in value.headers:

--- a/src/hishel/_sync_httpx.py
+++ b/src/hishel/_sync_httpx.py
@@ -37,6 +37,7 @@ SOCKET_OPTION = t.Union[
     t.Tuple[int, int, None, int],
 ]
 
+
 @overload
 def _internal_to_httpx(
     value: Request,
@@ -114,9 +115,7 @@ def _httpx_to_internal(
             metadata=headers_metadata,
         )
     elif isinstance(value, httpx.Response):
-        stream = (
-            make_sync_iterator([value.content]) if value.is_stream_consumed else value.iter_raw()
-        )
+        stream = make_sync_iterator([value.content]) if value.is_stream_consumed else value.iter_raw()
 
         if value.is_stream_consumed and "content-encoding" in value.headers:
             # If the stream was consumed and we don't know about

--- a/tests/test_async_httpx.py
+++ b/tests/test_async_httpx.py
@@ -119,3 +119,37 @@ async def test_encoded_content_caching() -> None:
         assert data == response_data
         assert response.headers.get("Content-Length") == str(len(data)) == str(len(response_data))
         assert response.headers.get("Content-Encoding") == "gzip"
+
+
+@pytest.mark.anyio
+async def test_small_stream_chunks_are_not_buffered() -> None:
+    class SmallChunks(httpx.SyncByteStream, httpx.AsyncByteStream):
+        async def __aiter__(self):
+            yield b"data: 1\n\n"
+            yield b"data: 2\n\n"
+
+    mocked_responses = [
+        httpx.Response(
+            200,
+            stream=SmallChunks(),
+            headers={"Content-Type": "text/event-stream"},
+        )
+    ]
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if not mocked_responses:
+            raise RuntimeError("No more mocked responses available")
+        return mocked_responses.pop(0)
+
+    client = AsyncCacheClient(
+        transport=AsyncCacheTransport(
+            next_transport=MockTransport(handler=handler),
+            storage=AsyncSqliteStorage(connection=await anysqlite.connect(":memory:", check_same_thread=False)),
+            policy=FilterPolicy(),
+        ),
+    )
+
+    async with client.stream("get", "https://localhost", extensions={"hishel_spec_ignore": True}) as response:
+        chunks = [chunk async for chunk in response.aiter_raw()]
+
+    assert chunks == [b"data: 1\n\n", b"data: 2\n\n"]

--- a/tests/test_sync_httpx.py
+++ b/tests/test_sync_httpx.py
@@ -119,3 +119,37 @@ def test_encoded_content_caching() -> None:
         assert data == response_data
         assert response.headers.get("Content-Length") == str(len(data)) == str(len(response_data))
         assert response.headers.get("Content-Encoding") == "gzip"
+
+
+
+def test_small_stream_chunks_are_not_buffered() -> None:
+    class SmallChunks(httpx.SyncByteStream, httpx.AsyncByteStream):
+        def __iter__(self):
+            yield b"data: 1\n\n"
+            yield b"data: 2\n\n"
+
+    mocked_responses = [
+        httpx.Response(
+            200,
+            stream=SmallChunks(),
+            headers={"Content-Type": "text/event-stream"},
+        )
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if not mocked_responses:
+            raise RuntimeError("No more mocked responses available")
+        return mocked_responses.pop(0)
+
+    client = SyncCacheClient(
+        transport=SyncCacheTransport(
+            next_transport=MockTransport(handler=handler),
+            storage=SyncSqliteStorage(connection=sqlite3.connect(":memory:", check_same_thread=False)),
+            policy=FilterPolicy(),
+        ),
+    )
+
+    with client.stream("get", "https://localhost", extensions={"hishel_spec_ignore": True}) as response:
+        chunks = [chunk for chunk in response.iter_raw()]
+
+    assert chunks == [b"data: 1\n\n", b"data: 2\n\n"]


### PR DESCRIPTION
Fixes #450.

`_httpx_to_internal` called `aiter_raw(chunk_size=131072)`, so httpx's ByteChunker held the body until it filled 128KB or the stream closed. SSE and other small-chunk responses (LLM token streams, etc.) arrived in one dump at the end.

Leave `chunk_size` unset so chunks pass through as the transport yields them. Same change on the sync side.

Tested with a two-chunk `text/event-stream` body; both chunks come through separately instead of being concatenated.
