### PR TITLE
fix: preserve httpx request extensions through cache transport round-trip

### DIFF
--- a/src/hishel/_async_httpx.py
+++ b/src/hishel/_async_httpx.py
@@ -55,6 +55,25 @@ def _httpx_extensions_from_metadata(metadata: t.Mapping[str, t.Any]) -> dict[str
     return extras
 
 
+# httpx request extensions that should survive the hishel round-trip on cache
+# miss but must NOT be persisted to cache (trace contains callables, timeout is
+# per-request). Using a separate key ensures filter_out_hishel_metadata drops them.
+KNOWN_HTTPX_REQUEST_EXTENSIONS = frozenset({"timeout", "sni_hostname", "trace", "target"})
+
+
+def _httpx_request_extensions_metadata(extensions: t.Mapping[str, t.Any]) -> dict[str, t.Any]:
+    httpx_meta = {key: val for key, val in extensions.items() if key in KNOWN_HTTPX_REQUEST_EXTENSIONS}
+    return {"hishel_httpx_request": httpx_meta} if httpx_meta else {}
+
+
+def _httpx_request_extensions_from_metadata(metadata: t.Mapping[str, t.Any]) -> dict[str, t.Any]:
+    extras = dict(metadata)
+    httpx_meta = extras.pop("hishel_httpx_request", None)
+    if isinstance(httpx_meta, dict):
+        extras.update(httpx_meta)
+    return extras
+
+
 @overload
 def _internal_to_httpx(
     value: Request,
@@ -75,7 +94,7 @@ def _internal_to_httpx(
             url=value.url,
             headers=value.headers,
             stream=_IteratorStream(value._aiter_stream()),
-            extensions=value.metadata,
+            extensions=_httpx_request_extensions_from_metadata(value.metadata),
         )
     elif isinstance(value, Response):
         return httpx.Response(
@@ -118,6 +137,8 @@ def _httpx_to_internal(
         for key, val in extension_metadata.items():
             if key in value.extensions:
                 headers_metadata[key] = val  # type: ignore
+
+        headers_metadata.update(_httpx_request_extensions_metadata(value.extensions))  # type: ignore
 
         try:
             stream = make_async_iterator([value.content])

--- a/src/hishel/_sync_httpx.py
+++ b/src/hishel/_sync_httpx.py
@@ -55,6 +55,25 @@ def _httpx_extensions_from_metadata(metadata: t.Mapping[str, t.Any]) -> dict[str
     return extras
 
 
+# httpx request extensions that should survive the hishel round-trip on cache
+# miss but must NOT be persisted to cache (trace contains callables, timeout is
+# per-request). Using a separate key ensures filter_out_hishel_metadata drops them.
+KNOWN_HTTPX_REQUEST_EXTENSIONS = frozenset({"timeout", "sni_hostname", "trace", "target"})
+
+
+def _httpx_request_extensions_metadata(extensions: t.Mapping[str, t.Any]) -> dict[str, t.Any]:
+    httpx_meta = {key: val for key, val in extensions.items() if key in KNOWN_HTTPX_REQUEST_EXTENSIONS}
+    return {"hishel_httpx_request": httpx_meta} if httpx_meta else {}
+
+
+def _httpx_request_extensions_from_metadata(metadata: t.Mapping[str, t.Any]) -> dict[str, t.Any]:
+    extras = dict(metadata)
+    httpx_meta = extras.pop("hishel_httpx_request", None)
+    if isinstance(httpx_meta, dict):
+        extras.update(httpx_meta)
+    return extras
+
+
 @overload
 def _internal_to_httpx(
     value: Request,
@@ -75,7 +94,7 @@ def _internal_to_httpx(
             url=value.url,
             headers=value.headers,
             stream=_IteratorStream(value._iter_stream()),
-            extensions=value.metadata,
+            extensions=_httpx_request_extensions_from_metadata(value.metadata),
         )
     elif isinstance(value, Response):
         return httpx.Response(
@@ -118,6 +137,8 @@ def _httpx_to_internal(
         for key, val in extension_metadata.items():
             if key in value.extensions:
                 headers_metadata[key] = val  # type: ignore
+
+        headers_metadata.update(_httpx_request_extensions_metadata(value.extensions))  # type: ignore
 
         try:
             stream = make_sync_iterator([value.content])

--- a/tests/test_async_httpx.py
+++ b/tests/test_async_httpx.py
@@ -181,3 +181,30 @@ async def test_body_key_survives_sending_request() -> None:
 
     assert len(await storage.get_entries(hashlib.sha256(b"hello").hexdigest())) == 1
     assert len(await storage.get_entries(hashlib.sha256(b"").hexdigest())) == 0
+
+
+@pytest.mark.anyio
+async def test_httpx_request_extensions_are_preserved() -> None:
+    captured_requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        return httpx.Response(
+            200,
+            content=b"ok",
+            headers={"Cache-Control": "max-age=3600", "Content-Type": "text/plain"},
+        )
+
+    client = AsyncCacheClient(
+        timeout=0.5,
+        transport=AsyncCacheTransport(
+            next_transport=MockTransport(handler=handler),
+            storage=AsyncSqliteStorage(connection=await anysqlite.connect(":memory:", check_same_thread=False)),
+        ),
+    )
+
+    await client.get("https://localhost", extensions={"sni_hostname": "custom.example.com"})
+
+    assert len(captured_requests) == 1
+    assert captured_requests[0].extensions["timeout"]["connect"] == 0.5
+    assert captured_requests[0].extensions["sni_hostname"] == "custom.example.com"

--- a/tests/test_sync_httpx.py
+++ b/tests/test_sync_httpx.py
@@ -181,3 +181,30 @@ def test_body_key_survives_sending_request() -> None:
 
     assert len(storage.get_entries(hashlib.sha256(b"hello").hexdigest())) == 1
     assert len(storage.get_entries(hashlib.sha256(b"").hexdigest())) == 0
+
+
+
+def test_httpx_request_extensions_are_preserved() -> None:
+    captured_requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        return httpx.Response(
+            200,
+            content=b"ok",
+            headers={"Cache-Control": "max-age=3600", "Content-Type": "text/plain"},
+        )
+
+    client = SyncCacheClient(
+        timeout=0.5,
+        transport=SyncCacheTransport(
+            next_transport=MockTransport(handler=handler),
+            storage=SyncSqliteStorage(connection=sqlite3.connect(":memory:", check_same_thread=False)),
+        ),
+    )
+
+    client.get("https://localhost", extensions={"sni_hostname": "custom.example.com"})
+
+    assert len(captured_requests) == 1
+    assert captured_requests[0].extensions["timeout"]["connect"] == 0.5
+    assert captured_requests[0].extensions["sni_hostname"] == "custom.example.com"


### PR DESCRIPTION
## Problem

When using `AsyncCacheTransport`/`SyncCacheTransport`, httpx request extensions (`timeout`, `sni_hostname`, `trace`, `target`) are silently dropped on cache misses. The client-level `timeout` never reaches httpcore, so requests can hang indefinitely.

## Fix

Following the pattern from PR #482 (`KNOWN_HTTPX_RESPONSE_EXTENSIONS`), this adds `KNOWN_HTTPX_REQUEST_EXTENSIONS` with a separate `hishel_httpx_request` metadata key. Extensions survive the in-memory round-trip on cache miss but are **not** persisted to cache (`trace` has callables, `timeout` is per-request) — the `hishel_` prefix ensures `filter_out_hishel_metadata` drops them during packing.

## Test

`test_httpx_request_extensions_are_preserved` verifies `timeout` and `sni_hostname` reach the inner transport on cache miss. Sync test auto-generated via `scripts/unasync`.

Fixes #484

> Generated with [OpenCode](https://opencode.ai) / GLM-5.2